### PR TITLE
Expose the config for client side caches, and enable them

### DIFF
--- a/entity-service-client/build.gradle.kts
+++ b/entity-service-client/build.gradle.kts
@@ -16,4 +16,5 @@ dependencies {
   implementation("org.slf4j:slf4j-api:1.7.30")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
+  testImplementation("org.mockito:mockito-core:3.3.3")
 }

--- a/entity-service-client/src/main/java/org/hypertrace/entity/data/service/client/EdsCacheClient.java
+++ b/entity-service-client/src/main/java/org/hypertrace/entity/data/service/client/EdsCacheClient.java
@@ -32,13 +32,14 @@ public class EdsCacheClient implements EdsClient {
   private final EntityDataServiceClient client;
 
   EdsCacheClient(EntityServiceClientConfig entityServiceClientConfig) {
-    this(new EntityDataServiceClient(entityServiceClientConfig));
-    initCache(entityServiceClientConfig.getCacheConfig());
+    this(new EntityDataServiceClient(entityServiceClientConfig),
+        entityServiceClientConfig.getCacheConfig());
   }
 
-  public EdsCacheClient(EntityDataServiceClient client) {
+  public EdsCacheClient(EntityDataServiceClient client,
+      EntityServiceClientCacheConfig cacheConfig) {
     this.client = client;
-    initCache(EntityServiceClientCacheConfig.DEFAULT);
+    initCache(cacheConfig);
   }
 
   private void initCache(EntityServiceClientCacheConfig cacheConfig) {

--- a/entity-service-client/src/main/java/org/hypertrace/entity/data/service/client/EdsCacheClient.java
+++ b/entity-service-client/src/main/java/org/hypertrace/entity/data/service/client/EdsCacheClient.java
@@ -92,8 +92,8 @@ public class EdsCacheClient implements EdsClient {
     EdsTypeAndIdAttributesCacheKey key = new EdsTypeAndIdAttributesCacheKey(tenantId,
         byIdentifyingAttributes);
     try {
-      String entityId = entityIdsCache.get(key).orElse(null);
-      return (entityId != null) ? getById(tenantId, entityId) : null;
+      Optional<String> entityId = entityIdsCache.get(key);
+      return (entityId.isPresent()) ? getById(tenantId, entityId.get()) : null;
     } catch (ExecutionException e) {
       LOG.error("Failed to fetch entity of tenantId: {}, entityId: {}",
           key.tenantId, key.byTypeAndIdentifyingAttributes, e);

--- a/entity-service-client/src/main/java/org/hypertrace/entity/data/service/client/EdsCacheKey.java
+++ b/entity-service-client/src/main/java/org/hypertrace/entity/data/service/client/EdsCacheKey.java
@@ -1,5 +1,7 @@
 package org.hypertrace.entity.data.service.client;
 
+import java.util.Objects;
+
 public class EdsCacheKey {
 
   public final String tenantId;
@@ -13,5 +15,19 @@ public class EdsCacheKey {
   @Override
   public String toString() {
     return String.format("__%s__%s", this.tenantId, this.entityId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(tenantId, entityId);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    EdsCacheKey that = (EdsCacheKey) o;
+    return Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(entityId, that.entityId);
   }
 }

--- a/entity-service-client/src/main/java/org/hypertrace/entity/data/service/client/EdsTypeAndIdAttributesCacheKey.java
+++ b/entity-service-client/src/main/java/org/hypertrace/entity/data/service/client/EdsTypeAndIdAttributesCacheKey.java
@@ -1,0 +1,40 @@
+package org.hypertrace.entity.data.service.client;
+
+import java.util.Objects;
+import org.hypertrace.entity.data.service.v1.ByTypeAndIdentifyingAttributes;
+
+public class EdsTypeAndIdAttributesCacheKey {
+
+  public final String tenantId;
+  public final ByTypeAndIdentifyingAttributes byTypeAndIdentifyingAttributes;
+
+  public EdsTypeAndIdAttributesCacheKey(String tenantId, ByTypeAndIdentifyingAttributes
+      byTypeAndIdentifyingAttributes) {
+    this.tenantId = tenantId;
+    this.byTypeAndIdentifyingAttributes = byTypeAndIdentifyingAttributes;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("__%s__%s", this.tenantId, this.byTypeAndIdentifyingAttributes);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(tenantId, byTypeAndIdentifyingAttributes);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    EdsTypeAndIdAttributesCacheKey that = (EdsTypeAndIdAttributesCacheKey) o;
+    return Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(byTypeAndIdentifyingAttributes, that.byTypeAndIdentifyingAttributes);
+  }
+
+}

--- a/entity-service-client/src/main/java/org/hypertrace/entity/data/service/client/exception/NotFoundException.java
+++ b/entity-service-client/src/main/java/org/hypertrace/entity/data/service/client/exception/NotFoundException.java
@@ -1,0 +1,8 @@
+package org.hypertrace.entity.data.service.client.exception;
+
+public class NotFoundException extends Exception {
+
+  public NotFoundException(String message) {
+    super(message);
+  }
+}

--- a/entity-service-client/src/main/java/org/hypertrace/entity/service/client/config/EntityServiceClientCacheConfig.java
+++ b/entity-service-client/src/main/java/org/hypertrace/entity/service/client/config/EntityServiceClientCacheConfig.java
@@ -1,0 +1,95 @@
+package org.hypertrace.entity.service.client.config;
+
+import com.typesafe.config.Config;
+
+/**
+ * Config class for cache config for different entity related caches at EntityService clients
+ * e.g
+ * entity.service.config = {
+ *  cache = {
+ *    entity.cache.expiry.ms = 30000
+ *    entity.max.cache.size = 1000
+ *    enriched.entity.cache.expiry.ms = 40000
+ *    enriched.entity.max.cache.size = 2000
+ *    entity.ids.cache.expiry.ms = 50000
+ *    entity.ids.max.cache.size = 3000
+ *  }
+ * }
+ */
+public class EntityServiceClientCacheConfig {
+
+  public static long DEFAULT_CACHE_EXPIRY_MS = 300000L;
+  public static long DEFAULT_MAX_CACHE_SIZE = 1000L;
+
+  private static final String ENTITY_CACHE_EXPIRY_MS = "entity.cache.expiry.ms";
+  private static final String ENTITY_MAX_CACHE_SIZE = "entity.max.cache.size";
+
+  private static final String ENRICHED_ENTITY_CACHE_EXPIRY_MS = "enriched.entity.cache.expiry.ms";
+  private static final String ENRICHED_ENTITY_MAX_CACHE_SIZE = "enriched.entity.max.cache.size";
+
+  private static final String ENTITY_IDS_CACHE_EXPIRY_MS = "entity.ids.cache.expiry.ms";
+  private static final String ENTITY_IDS_MAX_CACHE_SIZE = "entity.ids.max.cache.size";
+
+
+  public static final EntityServiceClientCacheConfig DEFAULT = new EntityServiceClientCacheConfig();
+
+  private long entityCacheExpiryMs;
+  private long entityMaxCacheSize;
+  private long enrichedEntityCacheExpiryMs;
+  private long enrichedEntityMaxCacheSize;
+  private long entityIdsCacheExpiryMs;
+  private long entityIdsMaxCacheSize;
+
+
+  public EntityServiceClientCacheConfig(Config clientCacheConfig) {
+    entityCacheExpiryMs = clientCacheConfig.hasPath(ENTITY_CACHE_EXPIRY_MS) ?
+        clientCacheConfig.getLong(ENTITY_CACHE_EXPIRY_MS) : DEFAULT_CACHE_EXPIRY_MS;
+    entityMaxCacheSize = clientCacheConfig.hasPath(ENTITY_MAX_CACHE_SIZE) ?
+        clientCacheConfig.getLong(ENTITY_MAX_CACHE_SIZE) : DEFAULT_MAX_CACHE_SIZE;
+
+    enrichedEntityCacheExpiryMs = clientCacheConfig.hasPath(ENRICHED_ENTITY_CACHE_EXPIRY_MS) ?
+        clientCacheConfig.getLong(ENRICHED_ENTITY_CACHE_EXPIRY_MS)
+        : DEFAULT_CACHE_EXPIRY_MS;
+    enrichedEntityMaxCacheSize = clientCacheConfig.hasPath(ENRICHED_ENTITY_MAX_CACHE_SIZE) ?
+        clientCacheConfig.getLong(ENRICHED_ENTITY_MAX_CACHE_SIZE)
+        : DEFAULT_MAX_CACHE_SIZE;
+
+    entityIdsCacheExpiryMs = clientCacheConfig.hasPath(ENTITY_IDS_CACHE_EXPIRY_MS) ?
+        clientCacheConfig.getLong(ENTITY_IDS_CACHE_EXPIRY_MS) : DEFAULT_CACHE_EXPIRY_MS;
+    entityIdsMaxCacheSize = clientCacheConfig.hasPath(ENTITY_IDS_MAX_CACHE_SIZE) ?
+        clientCacheConfig.getLong(ENTITY_IDS_MAX_CACHE_SIZE) : DEFAULT_MAX_CACHE_SIZE;
+  }
+
+  public EntityServiceClientCacheConfig() {
+    entityCacheExpiryMs = DEFAULT_CACHE_EXPIRY_MS;
+    entityMaxCacheSize = DEFAULT_MAX_CACHE_SIZE;
+    enrichedEntityCacheExpiryMs = DEFAULT_CACHE_EXPIRY_MS;
+    enrichedEntityMaxCacheSize = DEFAULT_MAX_CACHE_SIZE;
+    entityIdsCacheExpiryMs = DEFAULT_CACHE_EXPIRY_MS;
+    entityIdsMaxCacheSize = DEFAULT_MAX_CACHE_SIZE;
+  }
+
+  public long getEnrichedEntityCacheExpiryMs() {
+    return enrichedEntityCacheExpiryMs;
+  }
+
+  public long getEnrichedEntityMaxCacheSize() {
+    return enrichedEntityMaxCacheSize;
+  }
+
+  public long getEntityCacheExpiryMs() {
+    return entityCacheExpiryMs;
+  }
+
+  public long getEntityMaxCacheSize() {
+    return entityMaxCacheSize;
+  }
+
+  public long getEntityIdsCacheExpiryMs() {
+    return entityIdsCacheExpiryMs;
+  }
+
+  public long getEntityIdsMaxCacheSize() {
+    return entityIdsMaxCacheSize;
+  }
+}

--- a/entity-service-client/src/main/java/org/hypertrace/entity/service/client/config/EntityServiceClientConfig.java
+++ b/entity-service-client/src/main/java/org/hypertrace/entity/service/client/config/EntityServiceClientConfig.java
@@ -13,13 +13,16 @@ import com.typesafe.config.Config;
 public class EntityServiceClientConfig {
 
   private static final String ENTITY_SERVICE_CONFIG_KEY = "entity.service.config";
-
   private String host;
   private int port;
+  private final EntityServiceClientCacheConfig cacheConfig;
 
-  private EntityServiceClientConfig(String host, int port) {
-    this.host = host;
-    this.port = port;
+  private EntityServiceClientConfig(Config clientConfig) {
+    this.host = clientConfig.getString("host");
+    this.port = clientConfig.getInt("port");
+    this.cacheConfig = clientConfig.hasPath("cache") ?
+        new EntityServiceClientCacheConfig(clientConfig.getConfig("cache"))
+        : EntityServiceClientCacheConfig.DEFAULT;
   }
 
   public String getHost() {
@@ -30,10 +33,12 @@ public class EntityServiceClientConfig {
     return port;
   }
 
+  public EntityServiceClientCacheConfig getCacheConfig() {
+    return cacheConfig;
+  }
+
   public static EntityServiceClientConfig from(Config config) {
-    Config entityServiceConfig = config.getConfig(ENTITY_SERVICE_CONFIG_KEY);
-    return new EntityServiceClientConfig(
-        entityServiceConfig.getString("host"), entityServiceConfig.getInt("port"));
+    return new EntityServiceClientConfig(config.getConfig(ENTITY_SERVICE_CONFIG_KEY));
   }
 
   @Override

--- a/entity-service-client/src/test/java/org/hypertrace/entity/data/service/client/EdsCacheClientTest.java
+++ b/entity-service-client/src/test/java/org/hypertrace/entity/data/service/client/EdsCacheClientTest.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.hypertrace.entity.data.service.v1.AttributeValue;
 import org.hypertrace.entity.data.service.v1.ByTypeAndIdentifyingAttributes;
+import org.hypertrace.entity.data.service.v1.EnrichedEntity;
 import org.hypertrace.entity.data.service.v1.Entity;
 import org.hypertrace.entity.data.service.v1.Value;
 import org.hypertrace.entity.service.client.config.EntityServiceClientCacheConfig;
@@ -31,9 +32,9 @@ public class EdsCacheClientTest {
   }
 
   @Test
-  public void testByTypeAndIdentifyingAttributes() {
+  public void testGetByTypeAndIdentifyingAttributes() {
     String tenantId = "tenant";
-    String entityId = "e12345";
+    String entityId = "entity-12345";
 
     Map<String, AttributeValue> identifyingAttributesMap = new HashMap<>();
     identifyingAttributesMap.put("entity_name", AttributeValue.newBuilder()
@@ -64,6 +65,63 @@ public class EdsCacheClientTest {
     verify(entityDataServiceClient, times(1)).
         getByTypeAndIdentifyingAttributes("tenant", attributes);
     verify(entityDataServiceClient, never()).
-        getById("tenant", "e12345");
+        getById("tenant", "entity-12345");
   }
+
+  @Test
+  public void testGetEnrichedEntityById() {
+    String tenantId = "tenant";
+    String enrichedEntityId = "enriched-12345";
+
+    Map<String, AttributeValue> identifyingAttributesMap = new HashMap<>();
+    identifyingAttributesMap.put("entity_name", AttributeValue.newBuilder()
+        .setValue(Value.newBuilder().setString("GET /products").build()).build());
+    identifyingAttributesMap.put("is_active", AttributeValue.newBuilder()
+        .setValue(Value.newBuilder().setBoolean(true).build()).build());
+
+    EnrichedEntity enrichedEntity = EnrichedEntity.newBuilder()
+        .setEntityId(enrichedEntityId)
+        .setEntityType("API")
+        .setEntityName("GET /products")
+        .putAllIdentifyingAttributes(identifyingAttributesMap)
+        .build();
+
+    when(entityDataServiceClient.getEnrichedEntityById(anyString(), anyString()))
+        .thenReturn(enrichedEntity);
+
+    edsCacheClient.getEnrichedEntityById(tenantId, enrichedEntityId);
+    edsCacheClient.getEnrichedEntityById(tenantId, enrichedEntityId);
+
+    verify(entityDataServiceClient, times(1)).
+        getEnrichedEntityById("tenant", "enriched-12345");
+  }
+
+  @Test
+  public void testGetById() {
+    String tenantId = "tenant";
+    String entityId = "entity-12346";
+
+    Map<String, AttributeValue> identifyingAttributesMap = new HashMap<>();
+    identifyingAttributesMap.put("entity_name", AttributeValue.newBuilder()
+        .setValue(Value.newBuilder().setString("GET /products").build()).build());
+    identifyingAttributesMap.put("is_active", AttributeValue.newBuilder()
+        .setValue(Value.newBuilder().setBoolean(true).build()).build());
+
+    Entity entity = Entity.newBuilder()
+        .setTenantId(tenantId)
+        .setEntityId(entityId)
+        .setEntityType("API")
+        .setEntityName("GET /products")
+        .putAllIdentifyingAttributes(identifyingAttributesMap)
+        .build();
+
+    when(entityDataServiceClient.getById(anyString(), anyString())).thenReturn(entity);
+
+    edsCacheClient.getById(tenantId, entityId);
+    edsCacheClient.getById(tenantId, entityId);
+
+    verify(entityDataServiceClient, times(1)).
+        getById("tenant", "entity-12346");
+  }
+
 }

--- a/entity-service-client/src/test/java/org/hypertrace/entity/data/service/client/EdsCacheClientTest.java
+++ b/entity-service-client/src/test/java/org/hypertrace/entity/data/service/client/EdsCacheClientTest.java
@@ -16,6 +16,7 @@ import org.hypertrace.entity.data.service.v1.EnrichedEntity;
 import org.hypertrace.entity.data.service.v1.Entity;
 import org.hypertrace.entity.data.service.v1.Value;
 import org.hypertrace.entity.service.client.config.EntityServiceClientCacheConfig;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -69,6 +70,36 @@ public class EdsCacheClientTest {
   }
 
   @Test
+  public void testGetByTypeAndIdentifyingForNull() {
+    String tenantId = "tenant";
+
+    Map<String, AttributeValue> identifyingAttributesMap = new HashMap<>();
+    identifyingAttributesMap.put("entity_name", AttributeValue.newBuilder()
+        .setValue(Value.newBuilder().setString("GET /products").build()).build());
+    identifyingAttributesMap.put("is_active", AttributeValue.newBuilder()
+        .setValue(Value.newBuilder().setBoolean(true).build()).build());
+
+    when(entityDataServiceClient.getByTypeAndIdentifyingAttributes(anyString(), any()))
+        .thenReturn(null);
+
+    ByTypeAndIdentifyingAttributes attributes = ByTypeAndIdentifyingAttributes.newBuilder()
+        .setEntityType("API")
+        .putAllIdentifyingAttributes(identifyingAttributesMap)
+        .build();
+
+    Entity entity = edsCacheClient.getByTypeAndIdentifyingAttributes(tenantId, attributes);
+    Assertions.assertNull(entity);
+
+    entity = edsCacheClient.getByTypeAndIdentifyingAttributes(tenantId, attributes);
+    Assertions.assertNull(entity);
+
+    verify(entityDataServiceClient, times(2)).
+        getByTypeAndIdentifyingAttributes("tenant", attributes);
+    verify(entityDataServiceClient, never()).
+        getById("tenant", "entity-12345");
+  }
+
+  @Test
   public void testGetEnrichedEntityById() {
     String tenantId = "tenant";
     String enrichedEntityId = "enriched-12345";
@@ -97,6 +128,25 @@ public class EdsCacheClientTest {
   }
 
   @Test
+  public void testGetEnrichedEntityByIdForNull() {
+    String tenantId = "tenant";
+    String enrichedEntityId = "enriched-12345";
+
+    when(entityDataServiceClient.getEnrichedEntityById(anyString(), anyString()))
+        .thenReturn(null);
+
+    EnrichedEntity enrichedEntity = edsCacheClient
+        .getEnrichedEntityById(tenantId, enrichedEntityId);
+    Assertions.assertNull(enrichedEntity);
+
+    enrichedEntity = edsCacheClient.getEnrichedEntityById(tenantId, enrichedEntityId);
+    Assertions.assertNull(enrichedEntity);
+
+    verify(entityDataServiceClient, times(2)).
+        getEnrichedEntityById("tenant", "enriched-12345");
+  }
+
+  @Test
   public void testGetById() {
     String tenantId = "tenant";
     String entityId = "entity-12346";
@@ -121,6 +171,23 @@ public class EdsCacheClientTest {
     edsCacheClient.getById(tenantId, entityId);
 
     verify(entityDataServiceClient, times(1)).
+        getById("tenant", "entity-12346");
+  }
+
+  @Test
+  public void testGetByIdForNull() {
+    String tenantId = "tenant";
+    String entityId = "entity-12346";
+
+    when(entityDataServiceClient.getById(anyString(), anyString())).thenReturn(null);
+
+    Entity entity = edsCacheClient.getById(tenantId, entityId);
+    Assertions.assertNull(entity);
+
+    entity = edsCacheClient.getById(tenantId, entityId);
+    Assertions.assertNull(entity);
+
+    verify(entityDataServiceClient, times(2)).
         getById("tenant", "entity-12346");
   }
 

--- a/entity-service-client/src/test/java/org/hypertrace/entity/data/service/client/EdsCacheClientTest.java
+++ b/entity-service-client/src/test/java/org/hypertrace/entity/data/service/client/EdsCacheClientTest.java
@@ -1,0 +1,69 @@
+package org.hypertrace.entity.data.service.client;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.hypertrace.entity.data.service.v1.AttributeValue;
+import org.hypertrace.entity.data.service.v1.ByTypeAndIdentifyingAttributes;
+import org.hypertrace.entity.data.service.v1.Entity;
+import org.hypertrace.entity.data.service.v1.Value;
+import org.hypertrace.entity.service.client.config.EntityServiceClientCacheConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class EdsCacheClientTest {
+
+  EdsCacheClient edsCacheClient;
+  EntityDataServiceClient entityDataServiceClient;
+
+  @BeforeEach
+  public void setUp() {
+    entityDataServiceClient = mock(EntityDataServiceClient.class);
+    edsCacheClient = new EdsCacheClient(entityDataServiceClient,
+        EntityServiceClientCacheConfig.DEFAULT);
+  }
+
+  @Test
+  public void testByTypeAndIdentifyingAttributes() {
+    String tenantId = "tenant";
+    String entityId = "e12345";
+
+    Map<String, AttributeValue> identifyingAttributesMap = new HashMap<>();
+    identifyingAttributesMap.put("entity_name", AttributeValue.newBuilder()
+        .setValue(Value.newBuilder().setString("GET /products").build()).build());
+    identifyingAttributesMap.put("is_active", AttributeValue.newBuilder()
+        .setValue(Value.newBuilder().setBoolean(true).build()).build());
+
+    Entity entity = Entity.newBuilder()
+        .setTenantId(tenantId)
+        .setEntityId(entityId)
+        .setEntityType("API")
+        .setEntityName("GET /products")
+        .putAllIdentifyingAttributes(identifyingAttributesMap)
+        .build();
+
+    when(entityDataServiceClient.getById(anyString(), anyString())).thenReturn(entity);
+    when(entityDataServiceClient.getByTypeAndIdentifyingAttributes(anyString(), any()))
+        .thenReturn(entity);
+
+    ByTypeAndIdentifyingAttributes attributes = ByTypeAndIdentifyingAttributes.newBuilder()
+        .setEntityType("API")
+        .putAllIdentifyingAttributes(identifyingAttributesMap)
+        .build();
+
+    edsCacheClient.getByTypeAndIdentifyingAttributes(tenantId, attributes);
+    edsCacheClient.getByTypeAndIdentifyingAttributes(tenantId, attributes);
+
+    verify(entityDataServiceClient, times(1)).
+        getByTypeAndIdentifyingAttributes("tenant", attributes);
+    verify(entityDataServiceClient, never()).
+        getById("tenant", "e12345");
+  }
+}

--- a/entity-service-client/src/test/java/org/hypertrace/entity/data/service/client/EdsTypeAndIdAttributesCacheKeyTest.java
+++ b/entity-service-client/src/test/java/org/hypertrace/entity/data/service/client/EdsTypeAndIdAttributesCacheKeyTest.java
@@ -1,0 +1,68 @@
+package org.hypertrace.entity.data.service.client;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.hypertrace.entity.data.service.v1.AttributeValue;
+import org.hypertrace.entity.data.service.v1.ByTypeAndIdentifyingAttributes;
+import org.hypertrace.entity.data.service.v1.Value;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for {@link EdsTypeAndIdAttributesCacheKey}
+ * */
+public class EdsTypeAndIdAttributesCacheKeyTest {
+
+  @Test
+  public void testEqualsHashcode() {
+    Map<String, AttributeValue> identifyingAttributesMap1 = new HashMap<>();
+    identifyingAttributesMap1.put("entity_name", AttributeValue.newBuilder()
+        .setValue(Value.newBuilder().setString("GET /products").build()).build());
+    identifyingAttributesMap1.put("is_active", AttributeValue.newBuilder()
+        .setValue(Value.newBuilder().setBoolean(true).build()).build());
+
+    ByTypeAndIdentifyingAttributes attributes1 = ByTypeAndIdentifyingAttributes.newBuilder()
+        .setEntityType("API")
+        .putAllIdentifyingAttributes(identifyingAttributesMap1)
+        .build();
+
+    // cacheKey1, cacheKey2 using same input
+    EdsTypeAndIdAttributesCacheKey cacheKey1 = new EdsTypeAndIdAttributesCacheKey("tenant1",
+        attributes1);
+    EdsTypeAndIdAttributesCacheKey cacheKey2 = new EdsTypeAndIdAttributesCacheKey("tenant1",
+        attributes1);
+
+    Assertions.assertEquals(cacheKey1, cacheKey2);
+    Assertions.assertEquals(cacheKey1.hashCode(), cacheKey2.hashCode());
+
+    // different tenant value
+    EdsTypeAndIdAttributesCacheKey cacheKey3 = new EdsTypeAndIdAttributesCacheKey("tenant2",
+        attributes1);
+    Assertions.assertNotEquals(cacheKey1, cacheKey3);
+
+    // only entity_type change, and same attributes
+    ByTypeAndIdentifyingAttributes attributes2 = ByTypeAndIdentifyingAttributes.newBuilder()
+        .setEntityType("SERVICE")
+        .putAllIdentifyingAttributes(identifyingAttributesMap1)
+        .build();
+    EdsTypeAndIdAttributesCacheKey cacheKey4 = new EdsTypeAndIdAttributesCacheKey("tenant1",
+        attributes2);
+    Assertions.assertNotEquals(cacheKey1, cacheKey4);
+
+    // entity_type is same, but attributes are different
+    Map<String, AttributeValue> identifyingAttributesMap2 = new HashMap<>();
+    identifyingAttributesMap1.put("entity_name", AttributeValue.newBuilder()
+        .setValue(Value.newBuilder().setString("GET /books").build()).build());
+    identifyingAttributesMap1.put("is_active", AttributeValue.newBuilder()
+        .setValue(Value.newBuilder().setBoolean(false).build()).build());
+
+    ByTypeAndIdentifyingAttributes attributes3 = ByTypeAndIdentifyingAttributes.newBuilder()
+        .setEntityType("API")
+        .putAllIdentifyingAttributes(identifyingAttributesMap2)
+        .build();
+    EdsTypeAndIdAttributesCacheKey cacheKey5 = new EdsTypeAndIdAttributesCacheKey("tenant1",
+        attributes3);
+    Assertions.assertNotEquals(cacheKey1, cacheKey5);
+  }
+
+}

--- a/entity-service-client/src/test/java/org/hypertrace/entity/service/client/config/EntityServiceClientCacheConfigTest.java
+++ b/entity-service-client/src/test/java/org/hypertrace/entity/service/client/config/EntityServiceClientCacheConfigTest.java
@@ -1,0 +1,66 @@
+package org.hypertrace.entity.service.client.config;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for {@link EntityServiceClientCacheConfig}
+ * */
+public class EntityServiceClientCacheConfigTest {
+
+  @Test
+  public void testEntityServiceClientCacheConfigFromConfig() {
+    Map<String, Object> entityServiceClientConfigMap = new HashMap<>();
+    Map<String, Object> map = new HashMap<>();
+    map.put("host", "localhost");
+    map.put("port", 50061);
+
+    Map<String, Integer> cacheConfigMap = new HashMap<>();
+    cacheConfigMap.put("entity.cache.expiry.ms", 5000);
+    cacheConfigMap.put("entity.max.cache.size", 10000);
+    cacheConfigMap.put("enriched.entity.cache.expiry.ms", 6000);
+    cacheConfigMap.put("enriched.entity.max.cache.size", 20000);
+    cacheConfigMap.put("entity.ids.cache.expiry.ms", 7000);
+    cacheConfigMap.put("entity.ids.max.cache.size", 30000);
+    map.put("cache", cacheConfigMap);
+
+
+    entityServiceClientConfigMap.put("entity.service.config", map);
+    Config config = ConfigFactory.parseMap(entityServiceClientConfigMap);
+
+    EntityServiceClientConfig entityServiceClientConfig = EntityServiceClientConfig.from(config);
+    EntityServiceClientCacheConfig cacheConfig = entityServiceClientConfig.getCacheConfig();
+    Assertions.assertEquals(5000, cacheConfig.getEntityCacheExpiryMs());
+    Assertions.assertEquals(10000, cacheConfig.getEntityMaxCacheSize());
+    Assertions.assertEquals(6000, cacheConfig.getEnrichedEntityCacheExpiryMs());
+    Assertions.assertEquals(20000, cacheConfig.getEnrichedEntityMaxCacheSize());
+    Assertions.assertEquals(7000, cacheConfig.getEntityIdsCacheExpiryMs());
+    Assertions.assertEquals(30000, cacheConfig.getEntityIdsMaxCacheSize());
+
+  }
+
+  @Test
+  public void testEntityServiceClientDefaultCacheConfigFromConfig() {
+    Map<String, Object> entityServiceClientConfigMap = new HashMap<>();
+    Map<String, Object> map = new HashMap<>();
+    map.put("host", "localhost");
+    map.put("port", 50061);
+    entityServiceClientConfigMap.put("entity.service.config", map);
+    Config config = ConfigFactory.parseMap(entityServiceClientConfigMap);
+
+    EntityServiceClientConfig entityServiceClientConfig = EntityServiceClientConfig.from(config);
+    EntityServiceClientCacheConfig cacheConfig = entityServiceClientConfig.getCacheConfig();
+    Assertions.assertEquals(300000L, cacheConfig.getEntityCacheExpiryMs());
+    Assertions.assertEquals(1000, cacheConfig.getEntityMaxCacheSize());
+    Assertions.assertEquals(300000L, cacheConfig.getEnrichedEntityCacheExpiryMs());
+    Assertions.assertEquals(1000, cacheConfig.getEnrichedEntityMaxCacheSize());
+    Assertions.assertEquals(300000L, cacheConfig.getEntityIdsCacheExpiryMs());
+    Assertions.assertEquals(1000, cacheConfig.getEntityIdsMaxCacheSize());
+
+  }
+
+}


### PR DESCRIPTION
- enables the client-side caches for most common types of ID-based queries
- adds new cache for queries based on identifying attributes and type
- exposes the cache-related constants to config