### PR TITLE
fix: include customerId field as well when filtering for tenantId

### DIFF
--- a/entity-service-impl/src/main/java/org/hypertrace/entity/data/service/EntityDataServiceImpl.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/data/service/EntityDataServiceImpl.java
@@ -471,7 +471,7 @@ public class EntityDataServiceImpl extends EntityDataServiceImplBase {
       Map<String, AttributeValue> attributeMap) {
     Map<String, AttributeValue> map = new HashMap<>(attributeMap);
     // Add the tenantId and entityType to the map to make it more unique.
-    map.put("customerId",
+    map.put(EntityServiceConstants.CUSTOMER_ID,
         AttributeValue.newBuilder().setValue(Value.newBuilder().setString(tenantId)).build());
     map.put("entityType",
         AttributeValue.newBuilder().setValue(Value.newBuilder().setString(entityType)).build());

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/service/constants/EntityServiceConstants.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/service/constants/EntityServiceConstants.java
@@ -3,6 +3,7 @@ package org.hypertrace.entity.service.constants;
 public class EntityServiceConstants {
 
   public static final String TENANT_ID = "tenantId";
+  public static final String CUSTOMER_ID = "customerId";
 
   //EntityType constants
   public static final String NAME = "name";

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/service/util/DocStoreConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/service/util/DocStoreConverter.java
@@ -79,9 +79,26 @@ public class DocStoreConverter {
     return docStoreQuery;
   }
 
+  /**
+   * Since we decided to keep the customerId field around for old entities - to avoid entityId
+   * regeneration and backwards compatibility break - these entities are never
+   * upserted and hence the tenantId column has not been written into the document. So when creating
+   * the filter for tenantId, we need to match on both field names.
+   * @param tenantId
+   * @return OR filter on customerId and tenantId field names
+   */
   public static Filter getTenantIdEqFilter(String tenantId) {
-    return new Filter(Filter.Op.EQ, EntityServiceConstants.TENANT_ID, tenantId);
+    Filter filter = new Filter();
+    filter.setOp(Op.OR);
+    filter.setChildFilters(
+        new Filter[] {
+            new Filter(Filter.Op.EQ, EntityServiceConstants.TENANT_ID, tenantId),
+            new Filter(Filter.Op.EQ, EntityServiceConstants.CUSTOMER_ID, tenantId)
+        });
+
+    return filter;
   }
+
 
   private static Filter transform(AttributeFilter filter) {
     try {

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/service/util/DocStoreConverterTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/service/util/DocStoreConverterTest.java
@@ -41,9 +41,19 @@ public class DocStoreConverterTest {
     // Verify that the first filter is based on tenant id.
     Filter tenantIdFilter = transformedFilter.getChildFilters()[0];
 
-    Assertions.assertEquals(Op.EQ, tenantIdFilter.getOp());
-    Assertions.assertEquals(TENANT_ID, tenantIdFilter.getValue());
-    Assertions.assertEquals(EntityServiceConstants.TENANT_ID, tenantIdFilter.getFieldName());
+    // Verify tenantId filter. For backwards compatibility need to match on the old "customerId" field
+    // name.
+    Assertions.assertEquals(Op.OR, tenantIdFilter.getOp());
+    Assertions.assertEquals(2, tenantIdFilter.getChildFilters().length);
+    Assertions.assertEquals(null, tenantIdFilter.getValue());
+
+    Assertions.assertEquals(Op.EQ, tenantIdFilter.getChildFilters()[0].getOp());
+    Assertions.assertEquals(TENANT_ID, tenantIdFilter.getChildFilters()[0].getValue());
+    Assertions.assertEquals(EntityServiceConstants.TENANT_ID, tenantIdFilter.getChildFilters()[0].getFieldName());
+
+    Assertions.assertEquals(Op.EQ, tenantIdFilter.getChildFilters()[1].getOp());
+    Assertions.assertEquals(TENANT_ID, tenantIdFilter.getChildFilters()[1].getValue());
+    Assertions.assertEquals(EntityServiceConstants.CUSTOMER_ID, tenantIdFilter.getChildFilters()[1].getFieldName());
 
     Assertions.assertEquals(EntityServiceConstants.ENTITY_ID,
         transformedFilter.getChildFilters()[1].getFieldName());


### PR DESCRIPTION
For old entities - to avoid entityId regeneration and backwards compatibility break - that are never upserted with the newer tenantId