### PR TITLE
fix: filtering based on entity labels

### DIFF
--- a/entity-service-impl/src/main/java/org/hypertrace/entity/service/util/DocStoreConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/service/util/DocStoreConverter.java
@@ -32,6 +32,7 @@ public class DocStoreConverter {
   private static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static DocStoreJsonFormat.Printer JSONFORMAT_PRINTER = DocStoreJsonFormat.printer();
   private static final String ATTRIBUTES_LABELS_FIELD_NAME = "attributes.labels";
+  private static final String VALUE_LIST_VALUES_CONST = ".valueList.values";
 
   /**
    * Transforms entity to JSONDocument
@@ -131,7 +132,7 @@ public class DocStoreConverter {
 //  }
 
   private static void transformToOrFilterChainForStrArray(AttributeValue attributeValue, Filter filter) {
-    String fieldName = filter.getFieldName() + "." + "valueList" + "." + "values";
+    String fieldName = filter.getFieldName() + VALUE_LIST_VALUES_CONST;
 
     filter.setFieldName("");
     filter.setOp(Op.OR);
@@ -160,7 +161,7 @@ public class DocStoreConverter {
 
   private static void transformToEqFilterWithValueListRhs(AttributeValue attributeValue, Filter filter)
       throws InvalidProtocolBufferException, JsonProcessingException {
-    String fieldName = filter.getFieldName() + "." + "valueList" + "." + "values";
+    String fieldName = filter.getFieldName() + VALUE_LIST_VALUES_CONST;
     filter.setFieldName(fieldName);
 
     org.hypertrace.entity.data.service.v1.AttributeValue.TypeCase typeCase = attributeValue.getTypeCase();
@@ -251,9 +252,7 @@ public class DocStoreConverter {
           + "." + "value"
           + "." + fieldNameSuffix.orElse("string");
     } else {
-      return filter.getFieldName()
-          + "." + "valueList"
-          + "." + "values";
+      return filter.getFieldName() + VALUE_LIST_VALUES_CONST;
     }
   }
 

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/service/util/DocStoreConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/service/util/DocStoreConverter.java
@@ -88,27 +88,6 @@ public class DocStoreConverter {
     return new Filter(Filter.Op.EQ, EntityServiceConstants.TENANT_ID, tenantId);
   }
 
-  // TODO: Delete method
-  private static Filter transformOld(AttributeFilter filter) {
-    try {
-      Filter f = new Filter();
-      f.setFieldName(filter.getName());
-      f.setOp(transform(filter.getOperator()));
-      if (filter.hasAttributeValue()) {
-        transform(filter.getAttributeValue(), f, isPartOfAttributeMap(f.getFieldName()));
-      }
-
-      f.setChildFilters(
-          filter.getChildFilterList().stream()
-              .map(DocStoreConverter::transformOld)
-              .collect(Collectors.toList())
-              .toArray(new Filter[]{}));
-      return f;
-    } catch (IOException ioe) {
-      throw new IllegalArgumentException("Error converting filter for query");
-    }
-  }
-
   private static Filter transform(AttributeFilter filter) {
     try {
       if (filter.hasAttributeValue()) {


### PR DESCRIPTION
`labels EQUALS "foo"` translates to labels contains "foo" and AND chain means that the labels should contain all of the labels on the RHS side.
`labels IN ["foo","bar"]` translates to labels contains at least one of the labels in the RHS side of the filter.