### PR TITLE
refactor: add support for upsert of v1 or v2 typed entities

### DIFF
--- a/entity-service-impl/build.gradle.kts
+++ b/entity-service-impl/build.gradle.kts
@@ -6,17 +6,23 @@ plugins {
 
 dependencies {
   api(project(":entity-service-api"))
-  implementation("org.hypertrace.core.documentstore:document-store:0.3.2")
+  api("org.hypertrace.core.serviceframework:service-framework-spi:0.1.15")
+  implementation("org.hypertrace.core.documentstore:document-store:0.4.0")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.3.1")
+  implementation(project(":entity-type-service-rx-client"))
 
   implementation("com.google.protobuf:protobuf-java-util:3.13.0")
   implementation("com.github.f4b6a3:uuid-creator:2.5.1")
+  implementation("io.reactivex.rxjava3:rxjava:3.0.6")
+  implementation("com.google.guava:guava:30.0-jre")
 
   implementation("org.slf4j:slf4j-api:1.7.30")
   implementation("com.fasterxml.jackson.core:jackson-databind:2.11.1")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
-  testImplementation("org.mockito:mockito-core:3.3.3")
+  testImplementation("org.mockito:mockito-core:3.5.13")
+  testImplementation("org.mockito:mockito-junit-jupiter:3.5.13")
+  testRuntimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.13.3")
 }
 
 tasks.test {

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/data/service/DocumentParser.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/data/service/DocumentParser.java
@@ -1,0 +1,37 @@
+package org.hypertrace.entity.data.service;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import org.hypertrace.core.documentstore.Document;
+import org.hypertrace.entity.service.util.DocStoreJsonFormat;
+import org.hypertrace.entity.service.util.DocStoreJsonFormat.Parser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class DocumentParser {
+  private static final Logger LOG = LoggerFactory.getLogger(DocumentParser.class);
+  private static final Parser PARSER = DocStoreJsonFormat.parser().ignoringUnknownFields();
+
+  @SuppressWarnings("unchecked")
+  <T extends Message> T parseOrThrow(@Nonnull Document document, @Nonnull Message.Builder messageBuilder)
+      throws InvalidProtocolBufferException {
+    PARSER.merge(document.toJson(), messageBuilder);
+    return (T) messageBuilder.build();
+  }
+
+  <T extends Message> Optional<T> parseOrLog(
+      @Nonnull Document document, @Nonnull Message.Builder messageBuilder) {
+    try {
+      return Optional.of(this.parseOrThrow(document, messageBuilder));
+    } catch (Throwable throwable) {
+      LOG.error(
+          "Error processing document into message of type {}: {}",
+          messageBuilder.getDescriptorForType().getName(),
+          document.toJson(),
+          throwable);
+      return Optional.empty();
+    }
+  }
+}

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/data/service/EntityIdGenerator.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/data/service/EntityIdGenerator.java
@@ -1,0 +1,23 @@
+package org.hypertrace.entity.data.service;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.hypertrace.entity.data.service.v1.AttributeValue;
+import org.hypertrace.entity.data.service.v1.Value;
+import org.hypertrace.entity.service.util.UUIDGenerator;
+
+class EntityIdGenerator {
+
+
+  String generateEntityId(String tenantId, String entityType,
+                                  Map<String, AttributeValue> attributeMap) {
+    Map<String, AttributeValue> map = new HashMap<>(attributeMap);
+    // Add the tenantId and entityType to the map to make it more unique.
+    map.put("customerId",
+        AttributeValue.newBuilder().setValue(Value.newBuilder().setString(tenantId)).build());
+    map.put("entityType",
+        AttributeValue.newBuilder().setValue(Value.newBuilder().setString(entityType)).build());
+    return UUIDGenerator.generateUUID(map);
+  }
+
+}

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/data/service/EntityNormalizer.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/data/service/EntityNormalizer.java
@@ -1,0 +1,100 @@
+package org.hypertrace.entity.data.service;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.hypertrace.entity.data.service.EntityDataServiceImpl.ErrorMessages;
+import org.hypertrace.entity.data.service.v1.Entity;
+import org.hypertrace.entity.service.util.StringUtils;
+import org.hypertrace.entity.type.service.rxclient.EntityTypeClient;
+import org.hypertrace.entity.type.service.v1.AttributeType;
+
+class EntityNormalizer {
+  private final EntityTypeClient entityTypeV2Client;
+  private final EntityIdGenerator idGenerator;
+  private final IdentifyingAttributeCache identifyingAttributeCache;
+
+  EntityNormalizer(
+      EntityTypeClient entityTypeClient,
+      EntityIdGenerator idGenerator,
+      IdentifyingAttributeCache identifyingAttributeCache) {
+    this.entityTypeV2Client = entityTypeClient;
+    this.idGenerator = idGenerator;
+    this.identifyingAttributeCache = identifyingAttributeCache;
+  }
+
+  /**
+   * Normalizes the entity to a canonical, ready-to-upsert form
+   *
+   * @param receivedEntity
+   * @throws RuntimeException If entity can not be normalized
+   * @return
+   */
+  Entity normalize(String tenantId, Entity receivedEntity) {
+    if (StringUtils.isEmpty(receivedEntity.getEntityType())) {
+      throw new RuntimeException(ErrorMessages.ENTITY_TYPE_EMPTY);
+    }
+
+    if (this.requiresIdentifyingAttributes(receivedEntity)) {
+      return this.normalizeEntityByIdentifyingAttributes(tenantId, receivedEntity);
+    }
+    return this.normalizeEntityWithProvidedId(tenantId, receivedEntity);
+  }
+
+  private Entity normalizeEntityByIdentifyingAttributes(String tenantId, Entity receivedEntity) {
+    // Validate if all identifying attributes are present in the incoming entity
+    this.verifyMatchingIdentifyingAttributes(tenantId, receivedEntity);
+
+    // UUID is generated from identifying attributes.
+    String entityId =
+        this.idGenerator.generateEntityId(
+            tenantId, receivedEntity.getEntityType(), receivedEntity.getIdentifyingAttributesMap());
+
+    // Copy over the identify attributes to other attributes
+    return receivedEntity.toBuilder()
+        .putAllAttributes(receivedEntity.getIdentifyingAttributesMap())
+        .setEntityId(entityId)
+        .setTenantId(tenantId)
+        .build();
+  }
+
+  private Entity normalizeEntityWithProvidedId(String tenantId, Entity receivedEntity) {
+    return receivedEntity.toBuilder()
+        .putAllAttributes(receivedEntity.getIdentifyingAttributesMap())
+        .setTenantId(tenantId)
+        .build();
+  }
+
+  private boolean requiresIdentifyingAttributes(Entity entity) {
+    return this.entityTypeV2Client
+        .get(entity.getEntityType())
+        .map(
+            unused ->
+                entity
+                    .getEntityId()
+                    .isEmpty()) // If entity type is present, we require only if entity id is empty
+        .onErrorReturnItem(true)
+        .blockingGet();
+  }
+
+  private void verifyMatchingIdentifyingAttributes(String tenantId, Entity request) {
+    Set<String> idAttrNames =
+        this.identifyingAttributeCache
+            .getIdentifyingAttributes(tenantId, request.getEntityType())
+            .stream()
+            .map(AttributeType::getName)
+            .collect(Collectors.toSet());
+
+    if (idAttrNames.isEmpty()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "No identifying attributes defined for EntityType: %s", request.getEntityType()));
+    }
+
+    if (!idAttrNames.equals(request.getIdentifyingAttributesMap().keySet())) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Received and expected identifying attributes differ. Received: %s . Expected: %s",
+              request.getIdentifyingAttributesMap().keySet(), idAttrNames));
+    }
+  }
+}

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/data/service/IdentifyingAttributeCache.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/data/service/IdentifyingAttributeCache.java
@@ -1,0 +1,67 @@
+package org.hypertrace.entity.data.service;
+
+import static org.hypertrace.entity.service.constants.EntityCollectionConstants.ENTITY_TYPES_COLLECTION;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.Streams;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.hypertrace.core.documentstore.Collection;
+import org.hypertrace.core.documentstore.Datastore;
+import org.hypertrace.core.documentstore.Document;
+import org.hypertrace.core.documentstore.Filter;
+import org.hypertrace.core.documentstore.Filter.Op;
+import org.hypertrace.core.documentstore.Query;
+import org.hypertrace.entity.service.constants.EntityServiceConstants;
+import org.hypertrace.entity.service.util.TenantUtils;
+import org.hypertrace.entity.type.service.v1.AttributeType;
+import org.hypertrace.entity.type.service.v1.EntityType;
+
+class IdentifyingAttributeCache {
+  private static final DocumentParser PARSER = new DocumentParser();
+  private final LoadingCache<String, Map<String, List<AttributeType>>> cache;
+  private final Collection entityTypesCollection;
+
+  IdentifyingAttributeCache(Datastore datastore) {
+    this.entityTypesCollection = datastore.getCollection(ENTITY_TYPES_COLLECTION);
+    this.cache =
+        CacheBuilder.newBuilder()
+            .maximumWeight(1000)
+            .expireAfterWrite(15, TimeUnit.MINUTES)
+            .weigher((String key, Map<String, List<AttributeType>> value) -> value.size())
+            .build(CacheLoader.from(this::loadEntityTypes));
+  }
+
+  List<AttributeType> getIdentifyingAttributes(String tenantId, String entityTypeName) {
+    return this.cache.getUnchecked(tenantId).getOrDefault(entityTypeName, Collections.emptyList());
+  }
+
+  private Map<String, List<AttributeType>> loadEntityTypes(String tenantId) {
+    Query query = new Query();
+    query.setFilter(
+        new Filter(
+            Op.IN, EntityServiceConstants.TENANT_ID, TenantUtils.getTenantHierarchy(tenantId)));
+
+    return Streams.stream(entityTypesCollection.search(query))
+        .flatMap(this::buildEntityType)
+        .collect(
+            Collectors.toUnmodifiableMap(
+                EntityType::getName, this::getIdentifyingAttributesFromType));
+  }
+
+  private Stream<EntityType> buildEntityType(Document doc) {
+    return PARSER.<EntityType>parseOrLog(doc, EntityType.newBuilder()).stream();
+  }
+
+  private List<AttributeType> getIdentifyingAttributesFromType(EntityType entityType) {
+    return entityType.getAttributeTypeList().stream()
+        .filter(AttributeType::getIdentifyingAttribute)
+        .collect(Collectors.toList());
+  }
+}

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/data/service/DocumentParserTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/data/service/DocumentParserTest.java
@@ -1,0 +1,59 @@
+package org.hypertrace.entity.data.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+import org.hypertrace.core.documentstore.JSONDocument;
+import org.hypertrace.entity.data.service.v1.AttributeValue;
+import org.hypertrace.entity.data.service.v1.Entity;
+import org.hypertrace.entity.data.service.v1.Value;
+import org.junit.jupiter.api.Test;
+
+class DocumentParserTest {
+  private final Entity ENTITY =
+      Entity.newBuilder()
+          .setTenantId("tenant-id-1")
+          .setEntityType("ENTITY_TYPE")
+          .setEntityId(UUID.randomUUID().toString())
+          .setEntityName("Test entity")
+          .putAttributes(
+              "foo",
+              AttributeValue.newBuilder().setValue(Value.newBuilder().setString("foo1")).build())
+          .build();
+
+  private final JSONDocument GOOD_JSON = new JSONDocument(JsonFormat.printer().print(ENTITY));
+  // parser is very forgiving - give it a completely different data type to prevent it from
+  // defaulting
+  private final JSONDocument BAD_JSON = new JSONDocument("{\"entityId\": [1, 2]}");
+  private final DocumentParser PARSER = new DocumentParser();
+
+  DocumentParserTest() throws IOException {}
+
+  @Test
+  void throwIfFailedParseOrThrow() {
+    assertThrows(
+        InvalidProtocolBufferException.class,
+        () -> PARSER.parseOrThrow(BAD_JSON, Entity.newBuilder()));
+  }
+
+  @Test
+  void returnsMessageIfAbleToParseOrThrow() throws InvalidProtocolBufferException {
+    assertEquals(ENTITY, PARSER.parseOrThrow(GOOD_JSON, Entity.newBuilder()));
+  }
+
+  @Test
+  void returnsMessageOptionalIfAbleToParseOrLog() {
+
+    assertEquals(Optional.of(ENTITY), PARSER.parseOrLog(GOOD_JSON, Entity.newBuilder()));
+  }
+
+  @Test
+  void returnsEmptyOptionalIfFailedParseOrLog() {
+    assertEquals(Optional.empty(), PARSER.parseOrLog(BAD_JSON, Entity.newBuilder()));
+  }
+}

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/data/service/EntityNormalizerTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/data/service/EntityNormalizerTest.java
@@ -1,0 +1,155 @@
+package org.hypertrace.entity.data.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import io.reactivex.rxjava3.core.Single;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import org.hypertrace.entity.data.service.EntityDataServiceImpl.ErrorMessages;
+import org.hypertrace.entity.data.service.v1.AttributeValue;
+import org.hypertrace.entity.data.service.v1.Entity;
+import org.hypertrace.entity.data.service.v1.Value;
+import org.hypertrace.entity.type.service.rxclient.EntityTypeClient;
+import org.hypertrace.entity.type.service.v1.AttributeKind;
+import org.hypertrace.entity.type.service.v1.AttributeType;
+import org.hypertrace.entity.type.service.v2.EntityType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EntityNormalizerTest {
+  private static final String TENANT_ID = "tenant";
+  private static final String V1_ENTITY_TYPE = "v1-entity";
+  private static final String V2_ENTITY_TYPE = "v2-entity";
+  private static final AttributeType V1_ID_ATTR =
+      AttributeType.newBuilder()
+          .setIdentifyingAttribute(true)
+          .setValueKind(AttributeKind.TYPE_STRING)
+          .setName("required-attr")
+          .build();
+  @Mock EntityTypeClient mockEntityTypeClient;
+  @Mock EntityIdGenerator mockIdGenerator;
+  @Mock IdentifyingAttributeCache mockIdAttrCache;
+  private EntityNormalizer normalizer;
+
+  @BeforeEach
+  void beforeEach() {
+    this.normalizer = new EntityNormalizer(mockEntityTypeClient, mockIdGenerator, mockIdAttrCache);
+  }
+
+  @Test
+  void throwsOnMissingEntityType() {
+    Exception exception =
+        assertThrows(
+            RuntimeException.class,
+            () -> this.normalizer.normalize(TENANT_ID, Entity.getDefaultInstance()));
+    assertEquals(exception.getMessage(), ErrorMessages.ENTITY_TYPE_EMPTY);
+  }
+
+  @Test
+  void throwsOnV1EntityTypeMissingIdAttr() {
+    when(this.mockIdAttrCache.getIdentifyingAttributes(TENANT_ID, V1_ENTITY_TYPE))
+        .thenReturn(List.of(V1_ID_ATTR));
+    when(this.mockEntityTypeClient.get(V1_ENTITY_TYPE))
+        .thenReturn(Single.error(new RuntimeException()));
+    Entity inputEntity = Entity.newBuilder().setEntityType(V1_ENTITY_TYPE).build();
+
+    Exception exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> this.normalizer.normalize(TENANT_ID, inputEntity));
+    assertEquals(
+        "Received and expected identifying attributes differ. Received: [] . Expected: [required-attr]",
+        exception.getMessage());
+  }
+
+  @Test
+  void throwsOnV1EntityTypeWithExtraIdAttr() {
+    Map<String, AttributeValue> valueMap =
+        buildValueMap(Map.of(V1_ID_ATTR.getName(), "foo-value", "other", "other-value"));
+    when(this.mockIdAttrCache.getIdentifyingAttributes(TENANT_ID, V1_ENTITY_TYPE))
+        .thenReturn(List.of(V1_ID_ATTR));
+    when(this.mockEntityTypeClient.get(V1_ENTITY_TYPE))
+        .thenReturn(Single.error(new RuntimeException()));
+    Entity inputEntity =
+        Entity.newBuilder()
+            .setEntityType(V1_ENTITY_TYPE)
+            .putAllIdentifyingAttributes(valueMap)
+            .build();
+
+    Exception exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> this.normalizer.normalize(TENANT_ID, inputEntity));
+    assertEquals(
+        "Received and expected identifying attributes differ. Received: [other, required-attr] . Expected: [required-attr]",
+        exception.getMessage());
+  }
+
+  @Test
+  void throwsOnV2EntityMissingId() {
+    when(this.mockEntityTypeClient.get(V2_ENTITY_TYPE))
+        .thenReturn(Single.just(EntityType.getDefaultInstance()));
+    Entity inputEntity = Entity.newBuilder().setEntityType(V2_ENTITY_TYPE).build();
+
+    Exception exception =
+        assertThrows(
+            RuntimeException.class, () -> this.normalizer.normalize(TENANT_ID, inputEntity));
+    assertEquals(
+        exception.getMessage(), "No identifying attributes defined for EntityType: v2-entity");
+  }
+
+  @Test
+  void normalizesV1EntityWithAttrs() {
+    Map<String, AttributeValue> valueMap = buildValueMap(Map.of(V1_ID_ATTR.getName(), "foo-value"));
+    when(this.mockIdGenerator.generateEntityId(TENANT_ID, V1_ENTITY_TYPE, valueMap))
+        .thenReturn("generated-id");
+    when(this.mockIdAttrCache.getIdentifyingAttributes(TENANT_ID, V1_ENTITY_TYPE))
+        .thenReturn(List.of(V1_ID_ATTR));
+    when(this.mockEntityTypeClient.get(V1_ENTITY_TYPE))
+        .thenReturn(Single.error(new RuntimeException()));
+    Entity inputEntity =
+        Entity.newBuilder()
+            .setEntityType(V1_ENTITY_TYPE)
+            .putAllIdentifyingAttributes(valueMap)
+            .build();
+
+    Entity expectedNormalized =
+        inputEntity.toBuilder()
+            .setEntityId("generated-id")
+            .setTenantId(TENANT_ID)
+            .putAllAttributes(valueMap)
+            .build();
+    assertEquals(expectedNormalized, this.normalizer.normalize(TENANT_ID, inputEntity));
+  }
+
+  @Test
+  void normalizesV2EntityWithId() {
+    when(this.mockEntityTypeClient.get(V2_ENTITY_TYPE))
+        .thenReturn(Single.just(EntityType.getDefaultInstance()));
+    Entity inputEntity =
+        Entity.newBuilder().setEntityType(V2_ENTITY_TYPE).setEntityId("input-id").build();
+
+    Entity expectedNormalized = inputEntity.toBuilder().setTenantId(TENANT_ID).build();
+    assertEquals(expectedNormalized, this.normalizer.normalize(TENANT_ID, inputEntity));
+  }
+
+  private Map<String, AttributeValue> buildValueMap(Map<String, String> stringMap) {
+    return stringMap.entrySet().stream()
+        .map(
+            entry ->
+                Map.entry(
+                    entry.getKey(),
+                    AttributeValue.newBuilder()
+                        .setValue(Value.newBuilder().setString(entry.getValue()))
+                        .build()))
+        .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+  }
+}

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/data/service/IdentifyingAttributeCacheTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/data/service/IdentifyingAttributeCacheTest.java
@@ -1,0 +1,172 @@
+package org.hypertrace.entity.data.service;
+
+import static java.util.Collections.emptyList;
+import static org.hypertrace.entity.service.constants.EntityCollectionConstants.ENTITY_TYPES_COLLECTION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import com.google.protobuf.util.JsonFormat;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.hypertrace.core.documentstore.Collection;
+import org.hypertrace.core.documentstore.Datastore;
+import org.hypertrace.core.documentstore.Document;
+import org.hypertrace.core.documentstore.JSONDocument;
+import org.hypertrace.core.documentstore.Query;
+import org.hypertrace.entity.service.util.TenantUtils;
+import org.hypertrace.entity.type.service.v1.AttributeKind;
+import org.hypertrace.entity.type.service.v1.AttributeType;
+import org.hypertrace.entity.type.service.v1.EntityType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class IdentifyingAttributeCacheTest {
+
+  @Mock Collection mockCollection;
+
+  @Mock Datastore mockDataStore;
+
+  private IdentifyingAttributeCache cache;
+
+  @BeforeEach
+  void beforeEach() {
+    //    when (this.mockCollection.search(any())).then()
+    when(this.mockDataStore.getCollection(ENTITY_TYPES_COLLECTION)).thenReturn(this.mockCollection);
+    this.cache = new IdentifyingAttributeCache(this.mockDataStore);
+  }
+
+  @Test
+  void cachesDifferentEntityTypesSameTenant() {
+    when(this.mockCollection.search(
+            argThat(
+                (Query query) ->
+                    query.getFilter().getValue().equals(TenantUtils.getTenantHierarchy("tenant")))))
+        .thenReturn(
+            this.buildEntityTypeResponse(
+                Map.of(
+                    "first-type",
+                    List.of("first-attr", "second-attr"),
+                    "second-type",
+                    List.of("third-attr", "fourth-attr"))));
+    assertEquals(
+        List.of(this.buildIdAttrType("first-attr"), this.buildIdAttrType("second-attr")),
+        this.cache.getIdentifyingAttributes("tenant", "first-type"));
+
+    assertEquals(
+        List.of(this.buildIdAttrType("third-attr"), this.buildIdAttrType("fourth-attr")),
+        this.cache.getIdentifyingAttributes("tenant", "second-type"));
+    verify(this.mockCollection, times(1)).search(any());
+  }
+
+  @Test
+  void multipleConcurrentTenants() {
+    // Flip around mocks because of mockito ordering issues with custom matchers
+    doReturn(
+            this.buildEntityTypeResponse(
+                Map.of("first-type", List.of("first-attr", "second-attr"))))
+        .when(this.mockCollection)
+        .search(
+            argThat(
+                (Query query) ->
+                    query
+                        .getFilter()
+                        .getValue()
+                        .equals(TenantUtils.getTenantHierarchy("tenant-1"))));
+    doReturn(
+            this.buildEntityTypeResponse(
+                Map.of("first-type", List.of("third-attr", "fourth-attr"))))
+        .when(this.mockCollection)
+        .search(
+            argThat(
+                (Query query) ->
+                    query
+                        .getFilter()
+                        .getValue()
+                        .equals(TenantUtils.getTenantHierarchy("tenant-2"))));
+
+    assertEquals(
+        List.of(this.buildIdAttrType("first-attr"), this.buildIdAttrType("second-attr")),
+        this.cache.getIdentifyingAttributes("tenant-1", "first-type"));
+
+    assertEquals(
+        List.of(this.buildIdAttrType("third-attr"), this.buildIdAttrType("fourth-attr")),
+        this.cache.getIdentifyingAttributes("tenant-2", "first-type"));
+    verify(this.mockCollection, times(2)).search(any());
+  }
+
+  @Test
+  void errorResponseShouldNotBeCached() {
+    doThrow(UnsupportedOperationException.class).when(this.mockCollection).search(any());
+
+    assertThrows(
+        UncheckedExecutionException.class,
+        () -> this.cache.getIdentifyingAttributes("tenant", "first-type"));
+
+    doReturn(
+            this.buildEntityTypeResponse(
+                Map.of("first-type", List.of("first-attr", "second-attr"))))
+        .when(this.mockCollection)
+        .search(any());
+
+    assertEquals(
+        List.of(this.buildIdAttrType("first-attr"), this.buildIdAttrType("second-attr")),
+        this.cache.getIdentifyingAttributes("tenant", "first-type"));
+  }
+
+  @Test
+  void returnsEmptyListForUnknownEntityType() {
+    doReturn(
+            this.buildEntityTypeResponse(
+                Map.of("first-type", List.of("first-attr", "second-attr"))))
+        .when(this.mockCollection)
+        .search(any());
+
+    assertEquals(emptyList(), this.cache.getIdentifyingAttributes("tenant", "second-type"));
+  }
+
+  private Iterator<Document> buildEntityTypeResponse(
+      Map<String, List<String>> typeToAttributeTypeNames) {
+    return typeToAttributeTypeNames.entrySet().stream()
+        .map(entry -> this.buildEntityTypeDocForAttribute(entry.getKey(), entry.getValue()))
+        .iterator();
+  }
+
+  private Document buildEntityTypeDocForAttribute(String name, List<String> attributeTypeNames) {
+    try {
+      return new JSONDocument(
+          JsonFormat.printer()
+              .print(
+                  EntityType.newBuilder()
+                      .setName(name)
+                      .addAllAttributeType(
+                          attributeTypeNames.stream()
+                              .map(this::buildIdAttrType)
+                              .collect(Collectors.toList()))));
+    } catch (IOException exception) {
+      throw new RuntimeException(exception);
+    }
+  }
+
+  private AttributeType buildIdAttrType(String name) {
+    return AttributeType.newBuilder()
+        .setName(name)
+        .setValueKind(AttributeKind.TYPE_STRING)
+        .setIdentifyingAttribute(true)
+        .build();
+  }
+}

--- a/entity-service/build.gradle.kts
+++ b/entity-service/build.gradle.kts
@@ -59,7 +59,7 @@ dependencies {
   implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.3.1")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.3.1")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.15")
-  implementation("org.hypertrace.core.documentstore:document-store:0.3.2")
+  implementation("org.hypertrace.core.documentstore:document-store:0.4.0")
 
   runtimeOnly("io.grpc:grpc-netty:1.33.1")
   constraints {

--- a/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityDataServiceTest.java
+++ b/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityDataServiceTest.java
@@ -1,7 +1,9 @@
 package org.hypertrace.entity.service.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -29,12 +31,11 @@ import org.hypertrace.entity.data.service.v1.Entity;
 import org.hypertrace.entity.data.service.v1.Operator;
 import org.hypertrace.entity.data.service.v1.Query;
 import org.hypertrace.entity.data.service.v1.Value;
-import org.hypertrace.entity.query.service.client.EntityQueryServiceClient;
 import org.hypertrace.entity.service.client.config.EntityServiceClientConfig;
 import org.hypertrace.entity.service.client.config.EntityServiceTestConfig;
 import org.hypertrace.entity.service.constants.EntityConstants;
 import org.hypertrace.entity.service.constants.EntityServiceConstants;
-import org.hypertrace.entity.type.service.client.EntityTypeServiceClient;
+import org.hypertrace.entity.type.client.EntityTypeServiceClient;
 import org.hypertrace.entity.type.service.v1.AttributeKind;
 import org.hypertrace.entity.type.service.v1.AttributeType;
 import org.hypertrace.entity.v1.entitytype.EntityType;
@@ -49,9 +50,9 @@ import org.junit.jupiter.api.Test;
 public class EntityDataServiceTest {
 
   private static EntityDataServiceClient entityDataServiceClient;
-  private static EntityQueryServiceClient entityQueryServiceClient;
   private static final String TENANT_ID =
       "__testTenant__" + EntityDataServiceTest.class.getSimpleName();
+  private static final String TEST_ENTITY_TYPE_V2 = "TEST_ENTITY";
 
   @BeforeAll
   public static void setUp() {
@@ -60,8 +61,7 @@ public class EntityDataServiceTest {
     Channel channel = ClientInterceptors.intercept(ManagedChannelBuilder.forAddress(
         esConfig.getHost(), esConfig.getPort()).usePlaintext().build());
     entityDataServiceClient = new EntityDataServiceClient(channel);
-    entityQueryServiceClient = new EntityQueryServiceClient(channel);
-    setupEntityTypes();
+    setupEntityTypes(channel);
   }
 
   @AfterAll
@@ -69,40 +69,51 @@ public class EntityDataServiceTest {
     IntegrationTestServerUtil.shutdownServices();
   }
 
-  private static void setupEntityTypes() {
-    Channel channel = ClientInterceptors.intercept(ManagedChannelBuilder.forAddress(
-        EntityServiceTestConfig.getClientConfig().getHost(),
-        EntityServiceTestConfig.getClientConfig().getPort()).usePlaintext().build());
-    EntityTypeServiceClient entityTypeServiceClient = new EntityTypeServiceClient(channel);
-    entityTypeServiceClient.upsertEntityType(TENANT_ID,
+  private static void setupEntityTypes(Channel channel) {
+    org.hypertrace.entity.type.service.client.EntityTypeServiceClient entityTypeServiceV1Client = new org.hypertrace.entity.type.service.client.EntityTypeServiceClient(channel);
+    EntityTypeServiceClient entityTypeServiceV2Client = new EntityTypeServiceClient(channel);
+    entityTypeServiceV1Client.upsertEntityType(
+        TENANT_ID,
         org.hypertrace.entity.type.service.v1.EntityType.newBuilder()
             .setName(EntityType.K8S_POD.name())
-            .addAttributeType(AttributeType.newBuilder()
-                .setName(EntityConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_EXTERNAL_ID))
-                .setValueKind(AttributeKind.TYPE_STRING)
-                .setIdentifyingAttribute(true)
-                .build())
+            .addAttributeType(
+                AttributeType.newBuilder()
+                    .setName(EntityConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_EXTERNAL_ID))
+                    .setValueKind(AttributeKind.TYPE_STRING)
+                    .setIdentifyingAttribute(true)
+                    .build())
             .build());
-    entityTypeServiceClient
-        .upsertEntityType(TENANT_ID, org.hypertrace.entity.type.service.v1.EntityType
-            .newBuilder()
+    entityTypeServiceV1Client.upsertEntityType(
+        TENANT_ID,
+        org.hypertrace.entity.type.service.v1.EntityType.newBuilder()
             .setName(EntityType.BACKEND.name())
-            .addAttributeType(AttributeType.newBuilder()
-                .setName(EntityConstants.getValue(BackendAttribute.BACKEND_ATTRIBUTE_HOST))
-                .setValueKind(AttributeKind.TYPE_STRING)
-                .setIdentifyingAttribute(true)
-                .build())
-            .addAttributeType(AttributeType.newBuilder()
-                .setName(EntityConstants.getValue(BackendAttribute.BACKEND_ATTRIBUTE_PORT))
-                .setValueKind(AttributeKind.TYPE_STRING)
-                .setIdentifyingAttribute(true)
-                .build())
-            .addAttributeType(AttributeType.newBuilder()
-                .setName(EntityConstants.getValue(BackendAttribute.BACKEND_ATTRIBUTE_PROTOCOL))
-                .setValueKind(AttributeKind.TYPE_STRING)
-                .setIdentifyingAttribute(true)
-                .build())
+            .addAttributeType(
+                AttributeType.newBuilder()
+                    .setName(EntityConstants.getValue(BackendAttribute.BACKEND_ATTRIBUTE_HOST))
+                    .setValueKind(AttributeKind.TYPE_STRING)
+                    .setIdentifyingAttribute(true)
+                    .build())
+            .addAttributeType(
+                AttributeType.newBuilder()
+                    .setName(EntityConstants.getValue(BackendAttribute.BACKEND_ATTRIBUTE_PORT))
+                    .setValueKind(AttributeKind.TYPE_STRING)
+                    .setIdentifyingAttribute(true)
+                    .build())
+            .addAttributeType(
+                AttributeType.newBuilder()
+                    .setName(EntityConstants.getValue(BackendAttribute.BACKEND_ATTRIBUTE_PROTOCOL))
+                    .setValueKind(AttributeKind.TYPE_STRING)
+                    .setIdentifyingAttribute(true)
+                    .build())
             .build());
+
+    entityTypeServiceV2Client.upsertEntityType(
+        TENANT_ID, org.hypertrace.entity.type.service.v2.EntityType.newBuilder()
+                                                                   .setName(TEST_ENTITY_TYPE_V2)
+                                                                   .setAttributeScope(TEST_ENTITY_TYPE_V2)
+                                                                   .setIdAttributeKey("id")
+                                                                   .setNameAttributeKey("name")
+                                                                   .build());
   }
 
   @Test
@@ -162,7 +173,7 @@ public class EntityDataServiceTest {
   }
 
   @Test
-  public void testCreateWithoutIdentifyingAttributes() {
+  public void testCreateV1EntityTypeWithoutIdentifyingAttributes() {
     boolean upsertFailed = false;
     Entity entity = Entity.newBuilder()
         .setTenantId(TENANT_ID)
@@ -179,11 +190,32 @@ public class EntityDataServiceTest {
       assertEquals(Code.INTERNAL, sre.getStatus().getCode());
       assertNotNull(sre.getStatus().getDescription());
       assertTrue(sre.getStatus().getDescription().contains(
-          "required identifying attributes not present"));
+          "expected identifying attributes"));
     }
     if (!upsertFailed) {
-      fail("Expecting upsert to fail as identifying attributes are not set");
+      fail("Expecting upsert v1 typed entity to fail as identifying attributes are not set");
     }
+  }
+
+  @Test
+  public void testCreateV2EntityTypeWithoutIdentifyingAttributes() {
+    Entity firstInputEntity = Entity.newBuilder()
+                          .setTenantId(TENANT_ID)
+                          .setEntityType(TEST_ENTITY_TYPE_V2)
+                          .setEntityId(UUID.randomUUID().toString())
+                          .setEntityName("Test entity v2")
+                          .putAttributes("foo", AttributeValue.newBuilder().setValue(Value.newBuilder().setString("foo1")).build())
+                          .build();
+    Entity firstCreatedEntity = entityDataServiceClient.upsert(firstInputEntity);
+    assertNotSame(firstInputEntity, firstCreatedEntity);
+    assertEquals(firstInputEntity, firstCreatedEntity);
+
+    Entity secondInputEntity = firstInputEntity.toBuilder().clearAttributes()
+        .build();
+
+    Entity secondCreatedEntity = entityDataServiceClient.upsert(secondInputEntity);
+
+    assertEquals(firstCreatedEntity, secondCreatedEntity);
   }
 
   @Test

--- a/entity-type-service-rx-client/build.gradle.kts
+++ b/entity-type-service-rx-client/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
 
   implementation("org.slf4j:slf4j-api:1.7.30")
   implementation("com.google.guava:guava:30.0-jre")
+  implementation("io.reactivex.rxjava3:rxjava:3.0.6")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
   testImplementation("org.mockito:mockito-core:3.5.13")


### PR DESCRIPTION
The purpose of this change is to allow the upsert API to support entities formed by v1 entity types in addition to the existing v1 support. Both produce the same entity objects, but the data in those entities looks a bit different. V2 typed entities will always have an id, and don't use identifying attributes. V1 typed entities are the reverse, requiring identifying attributes and using those in place of an ID. The move to v2 entity types is to support generating ids dynamically and allowing code to generate and work with many entity attributes, including ID without calling into entity service.