### PR TITLE
feat: Upgrading docstore version, which brings 4.1.1 mongo java driver.

### DIFF
--- a/entity-service-impl/build.gradle.kts
+++ b/entity-service-impl/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 dependencies {
   api(project(":entity-service-api"))
   api("org.hypertrace.core.serviceframework:service-framework-spi:0.1.15")
-  implementation("org.hypertrace.core.documentstore:document-store:0.4.0")
+  implementation("org.hypertrace.core.documentstore:document-store:0.4.2")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.3.1")
   implementation(project(":entity-type-service-rx-client"))
 

--- a/entity-service/build.gradle.kts
+++ b/entity-service/build.gradle.kts
@@ -24,7 +24,7 @@ tasks.register<DockerRemoveNetwork>("removeIntegrationTestNetwork") {
 }
 
 tasks.register<DockerPullImage>("pullMongoImage") {
-  image.set("mongo:4.2.0")
+  image.set("mongo:4.4.0")
 }
 
 tasks.register<DockerCreateContainer>("createMongoContainer") {
@@ -59,7 +59,7 @@ dependencies {
   implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.3.1")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.3.1")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.15")
-  implementation("org.hypertrace.core.documentstore:document-store:0.4.0")
+  implementation("org.hypertrace.core.documentstore:document-store:0.4.2")
 
   runtimeOnly("io.grpc:grpc-netty:1.33.1")
   constraints {


### PR DESCRIPTION
## Description
Upgrading the docstore version to latest, which changes the mongo java driver used from 3.12 to 4.1.1. This is because the previous java driver is very old, marked legacy driver by MongoDB and there are a lot of bug fixes in the newer versions.

Most importantly, we are running into some issues with bulk upsert in production and we're trying to see if we see those same issues with the latest Mongo java driver too.

### Testing
Ran Hypertrace locally with the locally built image and things are working fine.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
No functionality is changed, hence no docs needed.