### PR TITLE
feat: Upgrading docstore version to workaround a bug fix for a known MongoDB server bug.

### DIFF
--- a/entity-service-impl/build.gradle.kts
+++ b/entity-service-impl/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 dependencies {
   api(project(":entity-service-api"))
   api("org.hypertrace.core.serviceframework:service-framework-spi:0.1.15")
-  implementation("org.hypertrace.core.documentstore:document-store:0.4.2")
+  implementation("org.hypertrace.core.documentstore:document-store:0.4.3")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.3.1")
   implementation(project(":entity-type-service-rx-client"))
 

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/data/service/EntityDataServiceImpl.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/data/service/EntityDataServiceImpl.java
@@ -560,7 +560,7 @@ public class EntityDataServiceImpl extends EntityDataServiceImplBase {
     }
 
     if (LOG.isDebugEnabled()) {
-      LOG.debug("MongoDB query has returned the result: {}", entities);
+      LOG.debug("Docstore query has returned the result: {}", entities);
     }
 
     if (entities.size() == 1) {
@@ -597,7 +597,7 @@ public class EntityDataServiceImpl extends EntityDataServiceImplBase {
                .collect(Collectors.toList());
 
     if (LOG.isDebugEnabled()) {
-      LOG.debug("MongoDB query has returned the result: {}", entities);
+      LOG.debug("Docstore query has returned the result: {}", entities);
     }
     responseObserver.onCompleted();
   }
@@ -620,7 +620,7 @@ public class EntityDataServiceImpl extends EntityDataServiceImplBase {
             .collect(Collectors.toList());
 
     if (LOG.isDebugEnabled()) {
-      LOG.debug("MongoDB query has returned the result: {}", relationships);
+      LOG.debug("Docstore query has returned the result: {}", relationships);
     }
     responseObserver.onCompleted();
   }

--- a/entity-service/build.gradle.kts
+++ b/entity-service/build.gradle.kts
@@ -59,7 +59,7 @@ dependencies {
   implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.3.1")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.3.1")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.15")
-  implementation("org.hypertrace.core.documentstore:document-store:0.4.2")
+  implementation("org.hypertrace.core.documentstore:document-store:0.4.3")
 
   runtimeOnly("io.grpc:grpc-netty:1.33.1")
   constraints {


### PR DESCRIPTION
See https://github.com/hypertrace/document-store/pull/13

The current MongoDB servers we use have a known issue - https://jira.mongodb.org/browse/SERVER-47212
where the findAndModify operation might fail with duplicate key exception and server was supposed to
retry that but it doesn't. Since the fix isn't available in the released MongoDB versions,
we are retrying the upserts in these cases in client layer so that we avoid frequent failures in this layer.