### PR TITLE
Adding unit tests for GRPC client retry code.

### DIFF
--- a/entity-service-client/build.gradle.kts
+++ b/entity-service-client/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   `java-library`
+  jacoco
   id("org.hypertrace.publish-plugin")
   id("org.hypertrace.jacoco-report-plugin")
 }

--- a/entity-service-client/build.gradle.kts
+++ b/entity-service-client/build.gradle.kts
@@ -15,6 +15,9 @@ dependencies {
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.3.1")
   implementation("org.slf4j:slf4j-api:1.7.30")
 
+  testImplementation("io.grpc:grpc-core:1.33.1")
   testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
-  testImplementation("org.mockito:mockito-core:3.3.3")
+  testImplementation("org.mockito:mockito-core:3.5.13")
+  testImplementation("org.mockito:mockito-junit-jupiter:3.5.13")
+  testImplementation("org.apache.logging.log4j:log4j-slf4j-impl:2.13.3")
 }

--- a/entity-service-client/src/main/java/org/hypertrace/entity/service/client/config/EntityServiceClientConfig.java
+++ b/entity-service-client/src/main/java/org/hypertrace/entity/service/client/config/EntityServiceClientConfig.java
@@ -13,8 +13,8 @@ import com.typesafe.config.Config;
 public class EntityServiceClientConfig {
 
   private static final String ENTITY_SERVICE_CONFIG_KEY = "entity.service.config";
-  private String host;
-  private int port;
+  private final String host;
+  private final int port;
   private final EntityServiceClientCacheConfig cacheConfig;
 
   private EntityServiceClientConfig(Config clientConfig) {

--- a/entity-service-client/src/test/java/org/hypertrace/entity/data/service/client/EntityDataServiceClientRetriesTest.java
+++ b/entity-service-client/src/test/java/org/hypertrace/entity/data/service/client/EntityDataServiceClientRetriesTest.java
@@ -1,0 +1,121 @@
+package org.hypertrace.entity.data.service.client;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.google.rpc.Code;
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import org.hypertrace.entity.data.service.v1.Entity;
+import org.hypertrace.entity.data.service.v1.EntityDataServiceGrpc;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link EntityDataServiceClient}
+ */
+@ExtendWith(MockitoExtension.class)
+public class EntityDataServiceClientRetriesTest {
+
+  @Mock
+  EntityDataServiceGrpc.EntityDataServiceImplBase mockDataService;
+
+  EntityDataServiceClient edsClient;
+  Server grpcServer;
+  ManagedChannel grpcChannel;
+
+  @BeforeEach
+  void beforeEach() throws IOException {
+    String uniqueName = InProcessServerBuilder.generateName();
+    this.grpcServer =
+        InProcessServerBuilder.forName(uniqueName)
+            .directExecutor() // directExecutor is fine for unit tests
+            .addService(this.mockDataService)
+            .build()
+            .start();
+    Map<String, Object> serviceConfig = Map.of(
+        "methodConfig", Collections.<Object>singletonList(Map.of(
+            "name", Collections.<Object>singletonList(Map.of("service", EntityDataServiceGrpc.getServiceDescriptor().getName())),
+            "retryPolicy", Map.of(
+                "maxAttempts", 3D,
+                "initialBackoff", "0.1s",
+                "maxBackoff", "5s",
+                "backoffMultiplier", 2D,
+                "retryableStatusCodes", Arrays.<Object>asList("UNAVAILABLE", "INTERNAL")
+            )
+            )
+        )
+    );
+    this.grpcChannel = InProcessChannelBuilder.forName(uniqueName)
+        .directExecutor()
+        .enableRetry()
+        .defaultServiceConfig(serviceConfig)
+        .build();
+
+    edsClient = new EntityDataServiceClient(this.grpcChannel);
+  }
+
+  @AfterEach
+  void afterEach() {
+    this.grpcServer.shutdownNow();
+    this.grpcChannel.shutdownNow();
+  }
+
+  @Test
+  public void testRetryForUnavailable() {
+    doAnswer(
+        invocation -> {
+          StreamObserver<Entity> observer = invocation.getArgument(1, StreamObserver.class);
+          observer.onError(new RuntimeException(new StatusRuntimeException(Status.UNAVAILABLE)));
+          return null;
+        })
+        .when(this.mockDataService)
+        .getById(any(), any());
+
+    try {
+      edsClient.getById("__default", "id1");
+    } catch (RuntimeException e) {
+      e.printStackTrace();
+      Assertions.assertTrue(e.getCause() instanceof StatusRuntimeException);
+      Assertions.assertEquals(Code.UNAVAILABLE.name(), ((StatusRuntimeException) e.getCause()).getStatus().getCode().name());
+    }
+    verify(this.mockDataService, times(3)).getById(any(), any());
+  }
+
+  @Test
+  public void testRetryForInternalError() {
+    doAnswer(
+        invocation -> {
+          StreamObserver<Entity> observer = invocation.getArgument(1, StreamObserver.class);
+          observer.onError(new RuntimeException(new StatusRuntimeException(Status.INTERNAL)));
+          return null;
+        })
+        .when(this.mockDataService)
+        .getById(any(), any());
+
+    try {
+      edsClient.getById("__default", "id1");
+    } catch (RuntimeException e) {
+      e.printStackTrace();
+      Assertions.assertTrue(e.getCause() instanceof StatusRuntimeException);
+      Assertions.assertEquals(Code.INTERNAL.name(), ((StatusRuntimeException) e.getCause()).getStatus().getCode().name());
+    }
+    verify(this.mockDataService, times(3)).getById(any(), any());
+  }
+}

--- a/entity-service-client/src/test/resources/log4j2.properties
+++ b/entity-service-client/src/test/resources/log4j2.properties
@@ -1,0 +1,6 @@
+status=error
+name=PropertiesConfig
+appender.console.type=Console
+appender.console.name=STDOUT
+rootLogger.level=INFO
+rootLogger.appenderRef.stdout.ref=STDOUT


### PR DESCRIPTION
## Description
Currently, there are no examples on how the GRPC clients or entity service clients can retry the requests, if it makes sense.
Adding unit tests which demonstrate how to do GRPC method retries so that it can be used by client applications.

### Testing
No changes to the service or client. Just added a few more unit tests.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
No changes so no need of new docs.