### PR TITLE
adding helm configs for supporting postgres

### DIFF
--- a/helm/templates/entity-service-config.yaml
+++ b/helm/templates/entity-service-config.yaml
@@ -28,10 +28,8 @@ data:
           {{- if .Values.entityServiceConfig.postgres.database }}
           database= {{ .Values.entityServiceConfig.postgres.database }}
           {{- end }}
-          {{- if .Values.entityServiceConfig.postgres.user }}
+          {{- if and .Values.entityServiceConfig.postgres.user .Values.entityServiceConfig.postgres.password }}
           user={{ .Values.entityServiceConfig.postgres.user }}
-          {{- end }}
-          {{- if .Values.entityServiceConfig.postgres.password }}
           password={{ .Values.entityServiceConfig.postgres.password }}
           {{- end }}
         }

--- a/helm/templates/entity-service-config.yaml
+++ b/helm/templates/entity-service-config.yaml
@@ -8,6 +8,8 @@ data:
   application.conf: |-
     entity.service.config = {
       entity-service {
+        dataStoreType = {{ .Values.entityServiceConfig.dataStoreType }}
+        {{- if eq .Values.entityServiceConfig.dataStoreType "mongo" }}
         mongo {
           {{- if .Values.entityServiceConfig.data.mongoUrl }}
           url = {{ .Values.entityServiceConfig.data.mongoUrl | quote }}
@@ -15,6 +17,25 @@ data:
           host = {{ .Values.entityServiceConfig.data.mongoHost }}
           {{- end }}
         }
+        {{ else if eq .Values.entityServiceConfig.dataStoreType "postgres" }}
+        postgres {
+          {{- if .Values.entityServiceConfig.postgres.url }}
+          url={{ .Values.entityServiceConfig.postgres.url | quote }}
+          {{- else }}
+          host={{ .Values.entityServiceConfig.postgres.host }}
+          port={{ .Values.entityServiceConfig.postgres.port }}
+          {{- end }}
+          {{- if .Values.entityServiceConfig.postgres.database }}
+          database= {{ .Values.entityServiceConfig.postgres.database }}
+          {{- end }}
+          {{- if .Values.entityServiceConfig.postgres.user }}
+          user={{ .Values.entityServiceConfig.postgres.user }}
+          {{- end }}
+          {{- if .Values.entityServiceConfig.postgres.password }}
+          password={{ .Values.entityServiceConfig.postgres.password }}
+          {{- end }}
+        }
+        {{- end }}
       }
     }
   {{- if .Values.attributes }}

--- a/helm/templates/entity-service-config.yaml
+++ b/helm/templates/entity-service-config.yaml
@@ -8,32 +8,15 @@ data:
   application.conf: |-
     entity.service.config = {
       entity-service {
-        dataStoreType = {{ .Values.entityServiceConfig.dataStoreType }}
-        {{- if eq .Values.entityServiceConfig.dataStoreType "mongo" }}
-        mongo {
-          {{- if .Values.entityServiceConfig.data.mongoUrl }}
-          url = {{ .Values.entityServiceConfig.data.mongoUrl | quote }}
-          {{- else }}
-          host = {{ .Values.entityServiceConfig.data.mongoHost }}
+        {{- $dst := .Values.entityServiceConfig.dataStoreType }}
+        dataStoreType = {{ $dst }}
+        {{ $dst }} {
+          {{- range $key, $value := (index .Values "entityServiceConfig" (printf "%s" $dst)) }}
+          {{- if $value }}
+          {{ $key }} = {{ $value | quote }}
+          {{- end }}
           {{- end }}
         }
-        {{ else if eq .Values.entityServiceConfig.dataStoreType "postgres" }}
-        postgres {
-          {{- if .Values.entityServiceConfig.postgres.url }}
-          url={{ .Values.entityServiceConfig.postgres.url | quote }}
-          {{- else }}
-          host={{ .Values.entityServiceConfig.postgres.host }}
-          port={{ .Values.entityServiceConfig.postgres.port }}
-          {{- end }}
-          {{- if .Values.entityServiceConfig.postgres.database }}
-          database= {{ .Values.entityServiceConfig.postgres.database }}
-          {{- end }}
-          {{- if and .Values.entityServiceConfig.postgres.user .Values.entityServiceConfig.postgres.password }}
-          user={{ .Values.entityServiceConfig.postgres.user }}
-          password={{ .Values.entityServiceConfig.postgres.password }}
-          {{- end }}
-        }
-        {{- end }}
       }
     }
   {{- if .Values.attributes }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -78,6 +78,7 @@ serviceSelectorLabels:
 ###########
 entityServiceConfig:
   name: entity-service-config
+  dataStoreType: "mongo"
   data:
     mongoHost: mongo
     mongoUrl: ""

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -81,6 +81,10 @@ entityServiceConfig:
   data:
     mongoHost: mongo
     mongoUrl: ""
+  postgres:
+    host: postgres
+    port: 5432
+    url: ""
 
 attributes: []
 extraAttributes: []

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -79,9 +79,9 @@ serviceSelectorLabels:
 entityServiceConfig:
   name: entity-service-config
   dataStoreType: "mongo"
-  data:
-    mongoHost: mongo
-    mongoUrl: ""
+  mongo:
+    host: mongo
+    url: ""
   postgres:
     host: postgres
     port: 5432


### PR DESCRIPTION
## Description
Adds helm configs for enabling support for postgres (see more details at hypertrace/hypertrace#124)

### Testing
Generate the helm templates locally running the below the commands

- helm dependency update ./helm/
- helm template ./helm/

Cases try by changing below values:

- dataStoreType: "postgres"
- dataStoreType: "mongo"

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
This specific change may not require, but when we update in docker-compose for postgres, we will document it.
