### PR TITLE
Adds limit and offset implementation

### DIFF
--- a/entity-service-api/src/main/proto/org/hypertrace/entity/data/service/v1/entity_data_request.proto
+++ b/entity-service-api/src/main/proto/org/hypertrace/entity/data/service/v1/entity_data_request.proto
@@ -40,6 +40,8 @@ message Query {
   string entity_type = 4;
   string entity_name = 5;
   AttributeFilter filter = 6;
+  int32 limit = 7;
+  int32 offset = 8;
 }
 
 message RelationshipsQuery {

--- a/entity-service-api/src/main/proto/org/hypertrace/entity/data/service/v1/entity_data_request.proto
+++ b/entity-service-api/src/main/proto/org/hypertrace/entity/data/service/v1/entity_data_request.proto
@@ -40,6 +40,7 @@ message Query {
   string entity_type = 4;
   string entity_name = 5;
   AttributeFilter filter = 6;
+  repeated OrderByExpression order_by = 9;
   int32 limit = 7;
   int32 offset = 8;
 }
@@ -55,4 +56,14 @@ message AttributeFilter {
   Operator operator = 2;
   AttributeValue attributeValue = 3;
   repeated AttributeFilter childFilter = 4;
+}
+
+message OrderByExpression {
+  string name = 1;
+  SortOrder order = 2;
+}
+
+enum SortOrder {
+  ASC = 0;
+  DESC = 1;
 }

--- a/entity-service-api/src/main/proto/org/hypertrace/entity/query/service/v1/entity_query_request.proto
+++ b/entity-service-api/src/main/proto/org/hypertrace/entity/query/service/v1/entity_query_request.proto
@@ -12,7 +12,7 @@ message EntityQueryRequest {
   string entityType = 2;
   Filter filter = 3;
   repeated Expression selection = 4;
-
+  repeated OrderByExpression orderBy = 7;
   int32 limit = 5;
   int32 offset = 6;
 }

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryConverter.java
@@ -32,6 +32,17 @@ public class EntityQueryConverter {
     if (attributeFilter != null) {
       queryBuilder.setFilter(attributeFilter);
     }
+
+    int limit = queryRequest.getLimit();
+    if (limit > 0) {
+      queryBuilder.setLimit(limit);
+    }
+
+    int offset = queryRequest.getOffset();
+    if (offset > 0) {
+      queryBuilder.setOffset(offset);
+    }
+
     return queryBuilder.build();
   }
 

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryConverter.java
@@ -2,8 +2,11 @@ package org.hypertrace.entity.query.service;
 
 import static java.util.stream.Collectors.toMap;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
@@ -17,6 +20,8 @@ import org.hypertrace.entity.query.service.v1.EntityQueryRequest;
 import org.hypertrace.entity.query.service.v1.Expression;
 import org.hypertrace.entity.query.service.v1.Filter;
 import org.hypertrace.entity.query.service.v1.LiteralConstant;
+import org.hypertrace.entity.query.service.v1.OrderByExpression;
+import org.hypertrace.entity.query.service.v1.SortOrder;
 import org.hypertrace.entity.query.service.v1.ValueType;
 import org.hypertrace.entity.service.constants.EntityServiceConstants;
 
@@ -33,15 +38,9 @@ public class EntityQueryConverter {
       queryBuilder.setFilter(attributeFilter);
     }
 
-    int limit = queryRequest.getLimit();
-    if (limit > 0) {
-      queryBuilder.setLimit(limit);
-    }
-
-    int offset = queryRequest.getOffset();
-    if (offset > 0) {
-      queryBuilder.setOffset(offset);
-    }
+    queryBuilder.addAllOrderBy(convertOrderBy(queryRequest.getOrderByList(), attrNameToEDSAttrMap));
+    queryBuilder.setLimit(queryRequest.getLimit());
+    queryBuilder.setOffset(queryRequest.getOffset());
 
     return queryBuilder.build();
   }
@@ -327,5 +326,41 @@ public class EntityQueryConverter {
         return Arrays.toString(values);
     }
     throw new IllegalArgumentException("Unhandled type: " + value.getTypeCase());
+  }
+
+  private static List<org.hypertrace.entity.data.service.v1.OrderByExpression> convertOrderBy(
+      List<OrderByExpression> orderByExpressions,
+      Map<String, String> attrNameToEDSAttrMap) {
+    if (orderByExpressions.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    List<org.hypertrace.entity.data.service.v1.OrderByExpression> result = new ArrayList<>();
+    for (OrderByExpression orderByExpression : orderByExpressions)
+      if (orderByExpression.hasExpression()) {
+        if (orderByExpression.getExpression().hasColumnIdentifier()) {
+          String edsColumnName = convertToAttributeKey(
+              orderByExpression.getExpression(), attrNameToEDSAttrMap);
+          org.hypertrace.entity.data.service.v1.OrderByExpression convertedExpression =
+              org.hypertrace.entity.data.service.v1.OrderByExpression.newBuilder()
+                  .setName(edsColumnName)
+                  .setOrder(convertSortOrder(orderByExpression.getOrder()))
+                  .build();
+          result.add(convertedExpression);
+        } else {
+          // entity data service and doc store only support field order by. There's no
+          // aggregate order by yet
+          throw new UnsupportedOperationException(
+              "OrderByExpression only support Column Identifier Expression");
+        }
+      }
+    return result;
+  }
+
+  private static org.hypertrace.entity.data.service.v1.SortOrder convertSortOrder(
+      SortOrder sortOrder) {
+    return SortOrder.DESC == sortOrder ?
+        org.hypertrace.entity.data.service.v1.SortOrder.DESC :
+        org.hypertrace.entity.data.service.v1.SortOrder.ASC;
   }
 }

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/service/util/DocStoreConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/service/util/DocStoreConverter.java
@@ -7,6 +7,7 @@ import com.google.protobuf.GeneratedMessageV3;
 import com.google.protobuf.InvalidProtocolBufferException;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -15,11 +16,14 @@ import javax.annotation.Nonnull;
 import org.hypertrace.core.documentstore.Filter;
 import org.hypertrace.core.documentstore.Filter.Op;
 import org.hypertrace.core.documentstore.JSONDocument;
+import org.hypertrace.core.documentstore.OrderBy;
 import org.hypertrace.entity.data.service.v1.AttributeFilter;
 import org.hypertrace.entity.data.service.v1.AttributeValue;
 import org.hypertrace.entity.data.service.v1.AttributeValue.TypeCase;
 import org.hypertrace.entity.data.service.v1.Operator;
+import org.hypertrace.entity.data.service.v1.OrderByExpression;
 import org.hypertrace.entity.data.service.v1.Query;
+import org.hypertrace.entity.data.service.v1.SortOrder;
 import org.hypertrace.entity.data.service.v1.Value;
 import org.hypertrace.entity.service.constants.EntityServiceConstants;
 
@@ -81,13 +85,34 @@ public class DocStoreConverter {
         docStoreQuery.setFilter(f);
       }
     }
+
+    if (query.getOrderByCount() > 0) {
+      docStoreQuery.addAllOrderBys(transformOrderBy(query.getOrderByList()));
+    }
+
     if (query.getLimit() > 0) {
       docStoreQuery.setLimit(query.getLimit());
     }
     if (query.getOffset() > 0) {
       docStoreQuery.setOffset(query.getOffset());
     }
+
     return docStoreQuery;
+  }
+
+  private static List<OrderBy> transformOrderBy(List<OrderByExpression> orderByExpressions) {
+    if (orderByExpressions.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    return orderByExpressions.stream()
+        .map(expression ->
+            new OrderBy(expression.getName(), transformSortOrder(expression.getOrder())))
+        .collect(Collectors.toList());
+  }
+
+  private static boolean transformSortOrder(SortOrder sortOrder) {
+    return SortOrder.ASC == sortOrder;
   }
 
   public static Filter getTenantIdEqFilter(String tenantId) {

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/service/util/DocStoreConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/service/util/DocStoreConverter.java
@@ -81,6 +81,12 @@ public class DocStoreConverter {
         docStoreQuery.setFilter(f);
       }
     }
+    if (query.getLimit() > 0) {
+      docStoreQuery.setLimit(query.getLimit());
+    }
+    if (query.getOffset() > 0) {
+      docStoreQuery.setOffset(query.getOffset());
+    }
     return docStoreQuery;
   }
 

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/EntityQueryConverterTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/EntityQueryConverterTest.java
@@ -1,0 +1,29 @@
+package org.hypertrace.entity.query.service;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import org.hypertrace.entity.data.service.v1.Query;
+import org.hypertrace.entity.query.service.v1.EntityQueryRequest;
+import org.junit.jupiter.api.Test;
+
+public class EntityQueryConverterTest {
+
+  @Test
+  public void test_convertToEDSQuery_limitAndOffset() {
+    // no offset and limit specified
+    EntityQueryRequest request = EntityQueryRequest.newBuilder().build();
+    Query convertedQuery = EntityQueryConverter.convertToEDSQuery(request, Collections.emptyMap());
+    assertEquals(0, convertedQuery.getOffset());
+    assertEquals(0, convertedQuery.getLimit());
+
+    int limit = 3;
+    int offset = 1;
+    request = EntityQueryRequest.newBuilder().setLimit(limit).setOffset(offset).build();
+    convertedQuery = EntityQueryConverter.convertToEDSQuery(request, Collections.emptyMap());
+    assertEquals(limit, convertedQuery.getLimit());
+    assertEquals(offset, convertedQuery.getOffset());
+  }
+
+}

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/service/util/DocStoreConverterTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/service/util/DocStoreConverterTest.java
@@ -31,6 +31,29 @@ public class DocStoreConverterTest {
   private static DocStoreJsonFormat.Printer JSONFORMAT_PRINTER = DocStoreJsonFormat.printer();
   private static final String ATTRIBUTES_LABELS_FIELD_NAME = "attributes.labels";
 
+
+  @Test
+  public void testEntityQueryLimitOffsetConversion() {
+    int limit = 2;
+    int offset = 1;
+    Query query = Query.newBuilder().addEntityId("some id").build();
+    org.hypertrace.core.documentstore.Query transformedQuery =
+        DocStoreConverter.transform(TENANT_ID, query);
+    Assertions.assertNull(transformedQuery.getLimit());
+    Assertions.assertNull(transformedQuery.getOffset());
+
+    query = Query.newBuilder().addEntityId("some id").setLimit(limit).setOffset(offset).build();
+    transformedQuery = DocStoreConverter.transform(TENANT_ID, query);
+    Assertions.assertEquals(limit, transformedQuery.getLimit());
+    Assertions.assertEquals(offset, transformedQuery.getOffset());
+
+    // zero values will be ignored
+    query = Query.newBuilder().addEntityId("some id").setLimit(0).setOffset(0).build();
+    transformedQuery = DocStoreConverter.transform(TENANT_ID, query);
+    Assertions.assertNull(transformedQuery.getLimit());
+    Assertions.assertNull(transformedQuery.getOffset());
+  }
+
   @Test
   public void testEntityFieldsQueryConversion() {
     Query query = Query.newBuilder().addEntityId("some id").build();
@@ -46,7 +69,6 @@ public class DocStoreConverterTest {
     Assertions.assertEquals(Op.EQ, tenantIdFilter.getOp());
     Assertions.assertEquals(TENANT_ID, tenantIdFilter.getValue());
     Assertions.assertEquals(EntityServiceConstants.TENANT_ID, tenantIdFilter.getFieldName());
-
     Assertions.assertEquals(EntityServiceConstants.ENTITY_ID,
         transformedFilter.getChildFilters()[1].getFieldName());
     Assertions.assertEquals(Collections.singletonList("some id"),

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/service/util/DocStoreConverterTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/service/util/DocStoreConverterTest.java
@@ -9,12 +9,15 @@ import java.util.Map;
 import org.hypertrace.core.documentstore.Filter;
 import org.hypertrace.core.documentstore.Filter.Op;
 import org.hypertrace.core.documentstore.JSONDocument;
+import org.hypertrace.core.documentstore.OrderBy;
 import org.hypertrace.entity.data.service.v1.AttributeFilter;
 import org.hypertrace.entity.data.service.v1.AttributeValue;
 import org.hypertrace.entity.data.service.v1.AttributeValueList;
 import org.hypertrace.entity.data.service.v1.Entity;
 import org.hypertrace.entity.data.service.v1.Operator;
+import org.hypertrace.entity.data.service.v1.OrderByExpression;
 import org.hypertrace.entity.data.service.v1.Query;
+import org.hypertrace.entity.data.service.v1.SortOrder;
 import org.hypertrace.entity.data.service.v1.Value;
 import org.hypertrace.entity.service.constants.EntityConstants;
 import org.hypertrace.entity.service.constants.EntityServiceConstants;
@@ -146,6 +149,31 @@ public class DocStoreConverterTest {
         transformedFilter.getChildFilters()[2].getFieldName());
     Assertions.assertEquals(Filter.Op.CONTAINS, transformedFilter.getChildFilters()[2].getOp());
     Assertions.assertEquals("stringValue", transformedFilter.getChildFilters()[2].getValue());
+  }
+
+  @Test
+  public void testOrderByConversion() {
+    Query query = Query.newBuilder()
+        .addEntityId("some id")
+        .addOrderBy(
+            OrderByExpression.newBuilder()
+                .setName("col1")
+                .setOrder(SortOrder.DESC)
+                .build())
+        .addOrderBy(
+            OrderByExpression.newBuilder()
+                .setName("col2")
+                .build())
+        .build();
+    org.hypertrace.core.documentstore.Query transformedQuery =
+        DocStoreConverter.transform(TENANT_ID, query);
+    List<OrderBy> transformedOrderBys= transformedQuery.getOrderBys();
+
+    Assertions.assertEquals(2, transformedOrderBys.size());
+    Assertions.assertEquals("col1", transformedOrderBys.get(0).getField());
+    Assertions.assertFalse(transformedOrderBys.get(0).isAsc());
+    Assertions.assertEquals("col2", transformedOrderBys.get(1).getField());
+    Assertions.assertTrue(transformedOrderBys.get(1).isAsc());
   }
 
   @Test

--- a/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityDataServiceTest.java
+++ b/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityDataServiceTest.java
@@ -322,6 +322,22 @@ public class EntityDataServiceTest {
     List<Entity> entitiesList = entityDataServiceClient.query(TENANT_ID, entityTypeQuery);
     assertTrue(entitiesList.size() > 1);
 
+    Query entityLimitQuery = Query.newBuilder()
+        .setEntityType(EntityType.K8S_POD.name())
+        .setLimit(1)
+        .build();
+    entitiesList = entityDataServiceClient.query(TENANT_ID, entityLimitQuery);
+    assertEquals(1,entitiesList.size());
+
+    Query entityOffsetQuery = Query.newBuilder()
+        .setEntityType(EntityType.K8S_POD.name())
+        .setLimit(1)
+        .setOffset(1)
+        .build();
+    List<Entity> entityWithOffset = entityDataServiceClient.query(TENANT_ID, entityOffsetQuery);
+    assertEquals(1, entityWithOffset.size());
+    assertNotEquals(entitiesList.get(0).getEntityId(), entityWithOffset.get(0).getEntityId());
+
     //Query specific entity
     Query entityTypeAndIdQuery = Query.newBuilder()
         .addEntityId(createdEntity1.getEntityId())

--- a/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityDataServiceTest.java
+++ b/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityDataServiceTest.java
@@ -360,74 +360,6 @@ public class EntityDataServiceTest {
   }
 
   @Test
-  public void testEntityQueryOrderBy() {
-    Entity entity1 = Entity.newBuilder()
-        .setTenantId(TENANT_ID)
-        .setEntityType(EntityType.K8S_POD.name())
-        .setEntityName("Some Service 1")
-        .putIdentifyingAttributes(
-            EntityConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_EXTERNAL_ID),
-            generateRandomUUIDAttrValue())
-        .putAttributes(
-            "foo",
-            AttributeValue.newBuilder()
-                .setValue(Value.newBuilder().setInt(5).build())
-                .build())
-        .build();
-    Entity createdEntity1 = entityDataServiceClient.upsert(entity1);
-    assertNotNull(createdEntity1);
-    assertNotNull(createdEntity1.getEntityId().trim());
-
-    Entity entity2 = Entity.newBuilder()
-        .setTenantId(TENANT_ID)
-        .setEntityType(EntityType.K8S_POD.name())
-        .setEntityName("Some Service 2")
-        .putIdentifyingAttributes(
-            EntityConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_EXTERNAL_ID),
-            generateRandomUUIDAttrValue())
-        .putAttributes(
-            "foo",
-            AttributeValue.newBuilder()
-                .setValue(Value.newBuilder().setInt(10).build())
-                .build())
-        .build();
-    Entity createdEntity2 = entityDataServiceClient.upsert(entity2);
-    assertNotNull(createdEntity2);
-    assertNotNull(createdEntity2.getEntityId().trim());
-
-    // Query by field name
-    Query entityNameQuery = Query.newBuilder()
-        .setEntityType(EntityType.K8S_POD.name())
-        .addOrderBy(
-            OrderByExpression.newBuilder()
-                .setOrder(SortOrder.DESC)
-                .setName("entityName")
-                .build())
-        .build();
-    List<Entity> entitiesList = entityDataServiceClient.query(TENANT_ID, entityNameQuery);
-    assertTrue(entitiesList.size() > 1);
-    assertTrue(entitiesList.contains(createdEntity1) && entitiesList.contains(createdEntity2));
-    // ordered such that entity with "larger" entity name value is listed earlier
-    assertTrue(entitiesList.indexOf(createdEntity2) < entitiesList.indexOf(createdEntity1));
-
-    // Query by attribute
-    Query attributeQuery = Query.newBuilder()
-        .setEntityType(EntityType.K8S_POD.name())
-        .addOrderBy(
-            OrderByExpression.newBuilder()
-                .setOrder(SortOrder.DESC)
-                .setName("attributes.foo")
-                .build())
-        .build();
-    entitiesList = entityDataServiceClient.query(TENANT_ID, attributeQuery);
-    assertTrue(entitiesList.size() > 1);
-    assertTrue(entitiesList.contains(createdEntity1) && entitiesList.contains(createdEntity2));
-    // ordered such that entity with "larger" attributes value is listed earlier
-    assertTrue(entitiesList.indexOf(createdEntity2) < entitiesList.indexOf(createdEntity1));
-
-  }
-
-  @Test
   public void testEntityQueryAttributeFiltering() {
     long timeBeforeQuery = System.currentTimeMillis();
     String stringRandomizer = UUID.randomUUID().toString();
@@ -714,6 +646,74 @@ public class EntityDataServiceTest {
     EnrichedEntity actualEntity2 = entityDataServiceClient
         .getEnrichedEntityById(TENANT_ID, entity2.getEntityId());
     assertEquals(entity2, actualEntity2);
+  }
+
+  @Test
+  public void testEntityQueryOrderBy() {
+    Entity entity1 = Entity.newBuilder()
+        .setTenantId(TENANT_ID)
+        .setEntityType(EntityType.K8S_POD.name())
+        .setEntityName("Some Service 1")
+        .putIdentifyingAttributes(
+            EntityConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_EXTERNAL_ID),
+            generateRandomUUIDAttrValue())
+        .putAttributes(
+            "foo",
+            AttributeValue.newBuilder()
+                .setValue(Value.newBuilder().setInt(5).build())
+                .build())
+        .build();
+    Entity createdEntity1 = entityDataServiceClient.upsert(entity1);
+    assertNotNull(createdEntity1);
+    assertNotNull(createdEntity1.getEntityId().trim());
+
+    Entity entity2 = Entity.newBuilder()
+        .setTenantId(TENANT_ID)
+        .setEntityType(EntityType.K8S_POD.name())
+        .setEntityName("Some Service 2")
+        .putIdentifyingAttributes(
+            EntityConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_EXTERNAL_ID),
+            generateRandomUUIDAttrValue())
+        .putAttributes(
+            "foo",
+            AttributeValue.newBuilder()
+                .setValue(Value.newBuilder().setInt(10).build())
+                .build())
+        .build();
+    Entity createdEntity2 = entityDataServiceClient.upsert(entity2);
+    assertNotNull(createdEntity2);
+    assertNotNull(createdEntity2.getEntityId().trim());
+
+    // Query by field name
+    Query entityNameQuery = Query.newBuilder()
+        .setEntityType(EntityType.K8S_POD.name())
+        .addOrderBy(
+            OrderByExpression.newBuilder()
+                .setOrder(SortOrder.DESC)
+                .setName("entityName")
+                .build())
+        .build();
+    List<Entity> entitiesList = entityDataServiceClient.query(TENANT_ID, entityNameQuery);
+    assertTrue(entitiesList.size() > 1);
+    assertTrue(entitiesList.contains(createdEntity1) && entitiesList.contains(createdEntity2));
+    // ordered such that entity with "larger" entity name value is listed earlier
+    assertTrue(entitiesList.indexOf(createdEntity2) < entitiesList.indexOf(createdEntity1));
+
+    // Query by attribute
+    Query attributeQuery = Query.newBuilder()
+        .setEntityType(EntityType.K8S_POD.name())
+        .addOrderBy(
+            OrderByExpression.newBuilder()
+                .setOrder(SortOrder.DESC)
+                .setName("attributes.foo")
+                .build())
+        .build();
+    entitiesList = entityDataServiceClient.query(TENANT_ID, attributeQuery);
+    assertTrue(entitiesList.size() > 1);
+    assertTrue(entitiesList.contains(createdEntity1) && entitiesList.contains(createdEntity2));
+    // ordered such that entity with "larger" attributes value is listed earlier
+    assertTrue(entitiesList.indexOf(createdEntity2) < entitiesList.indexOf(createdEntity1));
+
   }
 
   private AttributeValue generateRandomUUIDAttrValue() {


### PR DESCRIPTION
https://github.com/hypertrace/entity-service/issues/57
Need this implemented to allow batch fetching for large entities volume

EntityQueryService has limit and offset specified in the proto as part
of the Query message. However, there's no implementation and it's has been
faux attributes.

This adds the implementation of order, limit and offset

## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
