### PR TITLE
#60 Adding a new API which returns the previous entities before bulk upsert

### DIFF
--- a/entity-data-service-rx-client/src/main/java/org/hypertrace/entity/data/service/rxclient/EntityDataClient.java
+++ b/entity-data-service-rx-client/src/main/java/org/hypertrace/entity/data/service/rxclient/EntityDataClient.java
@@ -18,7 +18,7 @@ public interface EntityDataClient {
 
   /**
    * Gets the entity from the cache if available, otherwise upserts it and returns the result. The
-   * behavior of this may or may be cached depending on the configuration.
+   * behavior of this may or may not be cached depending on the configuration.
    *
    * @param entity
    * @return

--- a/entity-service-api/src/main/proto/org/hypertrace/entity/data/service/v1/entity_data_service.proto
+++ b/entity-service-api/src/main/proto/org/hypertrace/entity/data/service/v1/entity_data_service.proto
@@ -12,6 +12,7 @@ service EntityDataService {
   }
   rpc upsertEntities (Entities) returns (Empty) {
   }
+  rpc getAndUpsertEntities (Entities) returns (stream Entity) {}
   rpc delete (ByIdRequest) returns (Empty) {
   }
   rpc getById (ByIdRequest) returns (Entity) {

--- a/entity-service-client/src/main/java/org/hypertrace/entity/data/service/client/EdsCacheClient.java
+++ b/entity-service-client/src/main/java/org/hypertrace/entity/data/service/client/EdsCacheClient.java
@@ -3,8 +3,7 @@ package org.hypertrace.entity.data.service.client;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import io.grpc.Channel;
-import io.grpc.ManagedChannelBuilder;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -20,7 +19,6 @@ import org.hypertrace.entity.data.service.v1.EntityRelationship;
 import org.hypertrace.entity.data.service.v1.EntityRelationships;
 import org.hypertrace.entity.data.service.v1.Query;
 import org.hypertrace.entity.service.client.config.EntityServiceClientCacheConfig;
-import org.hypertrace.entity.service.client.config.EntityServiceClientConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,6 +86,11 @@ public class EdsCacheClient implements EdsClient {
   @Override
   public Entity upsert(Entity entity) {
     return client.upsert(entity);
+  }
+
+  @Override
+  public Iterator<Entity> getAndBulkUpsert(String tenantId, Collection<Entity> entities) {
+    return client.getAndBulkUpsert(tenantId, entities);
   }
 
   @Override

--- a/entity-service-client/src/main/java/org/hypertrace/entity/data/service/client/EdsClient.java
+++ b/entity-service-client/src/main/java/org/hypertrace/entity/data/service/client/EdsClient.java
@@ -1,5 +1,6 @@
 package org.hypertrace.entity.data.service.client;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -17,6 +18,8 @@ import org.hypertrace.entity.data.service.v1.Query;
 public interface EdsClient {
 
   Entity upsert(Entity entity);
+
+  Iterator<Entity> getAndBulkUpsert(String tenantId, Collection<Entity> entities);
 
   Entity getByTypeAndIdentifyingAttributes(String tenantId,
       ByTypeAndIdentifyingAttributes byIdentifyingAttributes);

--- a/entity-service-client/src/main/java/org/hypertrace/entity/data/service/client/EntityDataServiceClient.java
+++ b/entity-service-client/src/main/java/org/hypertrace/entity/data/service/client/EntityDataServiceClient.java
@@ -5,6 +5,7 @@ import static org.hypertrace.entity.service.constants.EntityConstants.attributeM
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import io.grpc.Channel;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -56,6 +57,11 @@ public class EntityDataServiceClient implements EdsClient {
       LOGGER.debug("Upserted entity: {}", result);
     }
     return result.equals(Entity.getDefaultInstance()) ? null : result;
+  }
+
+  @Override
+  public Iterator<Entity> getAndBulkUpsert(String tenantId, Collection<Entity> entities) {
+    return execute(tenantId, () -> blockingStub.getAndUpsertEntities(Entities.newBuilder().addAllEntity(entities).build()));
   }
 
   public void bulkUpsert(String tenantId, java.util.Collection<Entity> entities) {

--- a/entity-service-impl/build.gradle.kts
+++ b/entity-service-impl/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 dependencies {
   api(project(":entity-service-api"))
   api("org.hypertrace.core.serviceframework:service-framework-spi:0.1.18")
-  implementation("org.hypertrace.core.documentstore:document-store:0.4.5")
+  implementation("org.hypertrace.core.documentstore:document-store:0.4.6-SNAPSHOT")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.3.1")
   implementation(project(":entity-type-service-rx-client"))
 

--- a/entity-service-impl/build.gradle.kts
+++ b/entity-service-impl/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 dependencies {
   api(project(":entity-service-api"))
   api("org.hypertrace.core.serviceframework:service-framework-spi:0.1.18")
-  implementation("org.hypertrace.core.documentstore:document-store:0.4.6-SNAPSHOT")
+  implementation("org.hypertrace.core.documentstore:document-store:0.4.6")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.3.1")
   implementation(project(":entity-type-service-rx-client"))
 

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/data/service/EntityDataServiceImpl.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/data/service/EntityDataServiceImpl.java
@@ -148,7 +148,7 @@ public class EntityDataServiceImpl extends EntityDataServiceImplBase {
         documentMap.put(key, doc);
       }
 
-      Streams.stream(entitiesCollection.returnAndBulkUpsert(documentMap))
+      Streams.stream(entitiesCollection.bulkUpsertAndReturnOlderDocuments(documentMap))
           .flatMap(document -> PARSER.<Entity>parseOrLog(document, Entity.newBuilder()).stream())
           .map(Entity::toBuilder)
           .map(builder -> builder.setTenantId(tenantId))

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/data/service/EntityDataServiceImpl.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/data/service/EntityDataServiceImpl.java
@@ -127,6 +127,41 @@ public class EntityDataServiceImpl extends EntityDataServiceImplBase {
     }
   }
 
+  @Override
+  public void getAndUpsertEntities(Entities request, StreamObserver<Entity> responseObserver) {
+    String tenantId = RequestContext.CURRENT.get().getTenantId().orElse(null);
+    if (tenantId == null) {
+      responseObserver.onError(new ServiceException("Tenant id is missing in the request."));
+      return;
+    }
+
+    try {
+      Map<String, Entity> entityMap =
+          request.getEntityList().stream()
+              .map(entity -> this.upsertNormalizer.normalize(tenantId, entity))
+              .collect(Collectors.toUnmodifiableMap(Entity::getEntityId, Function.identity()));
+
+      Map<Key, Document> documentMap = new HashMap<>();
+      for (Map.Entry<String, Entity> entry : entityMap.entrySet()) {
+        Document doc = convertEntityToDocument(entry.getValue());
+        SingleValueKey key = new SingleValueKey(tenantId, entry.getKey());
+        documentMap.put(key, doc);
+      }
+
+      Streams.stream(entitiesCollection.returnAndBulkUpsert(documentMap))
+          .flatMap(document -> PARSER.<Entity>parseOrLog(document, Entity.newBuilder()).stream())
+          .map(Entity::toBuilder)
+          .map(builder -> builder.setTenantId(tenantId))
+          .map(Entity.Builder::build)
+          .forEach(responseObserver::onNext);
+
+      responseObserver.onCompleted();
+    } catch (IOException e) {
+      LOG.error("Failed to bulk upsert entities", e);
+      responseObserver.onError(e);
+    }
+  }
+
   /**
    * Get an Entity by the EntityId and EntityType
    *

--- a/entity-service/build.gradle.kts
+++ b/entity-service/build.gradle.kts
@@ -59,7 +59,7 @@ dependencies {
   implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.3.1")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.3.1")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.18")
-  implementation("org.hypertrace.core.documentstore:document-store:0.4.5")
+  implementation("org.hypertrace.core.documentstore:document-store:0.4.6")
 
   runtimeOnly("io.grpc:grpc-netty:1.33.1")
   constraints {


### PR DESCRIPTION
## Description
See #60 for more details.

### Testing
Integration tests are verifying the full logic.

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

This PR depends on https://github.com/hypertrace/document-store/pull/18 so build will fail until that's merged.