### PR TITLE
discarding printing of full config to avoid any sensitive data leak

### DIFF
--- a/entity-service/src/main/java/org/hypertrace/entity/service/EntityServiceConfig.java
+++ b/entity-service/src/main/java/org/hypertrace/entity/service/EntityServiceConfig.java
@@ -14,8 +14,6 @@ public class EntityServiceConfig {
   private final Config entityServiceConfig;
 
   public EntityServiceConfig(Config config) {
-
-    LOG.info(config.toString());
     entityServiceConfig = config.getConfig("entity-service");
     dataStoreType = entityServiceConfig.getString(DocumentStoreConfig.DATASTORE_TYPE_CONFIG_KEY);
   }


### PR DESCRIPTION
As part of the issue - https://github.com/hypertrace/hypertrace/issues/137, where we identified that some sensitive information is logged (password for postgres), we are going with option (a) listed in the issue. There is no need to print `config` here.

