### PR TITLE
Fix streaming large amount of data from entity-service

### DIFF
--- a/entity-service-impl/src/main/java/org/hypertrace/entity/data/service/DocumentParser.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/data/service/DocumentParser.java
@@ -10,7 +10,7 @@ import org.hypertrace.entity.service.util.DocStoreJsonFormat.Parser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class DocumentParser {
+public class DocumentParser {
   private static final Logger LOG = LoggerFactory.getLogger(DocumentParser.class);
   private static final Parser PARSER = DocStoreJsonFormat.parser().ignoringUnknownFields();
 
@@ -21,7 +21,7 @@ class DocumentParser {
     return (T) messageBuilder.build();
   }
 
-  <T extends Message> Optional<T> parseOrLog(
+  public <T extends Message> Optional<T> parseOrLog(
       @Nonnull Document document, @Nonnull Message.Builder messageBuilder) {
     try {
       return Optional.of(this.parseOrThrow(document, messageBuilder));

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/data/service/EntityDataServiceImpl.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/data/service/EntityDataServiceImpl.java
@@ -265,8 +265,15 @@ public class EntityDataServiceImpl extends EntityDataServiceImplBase {
       return;
     }
 
-    searchByQueryAndStreamResponse(
-        DocStoreConverter.transform(tenantId.get(), request), responseObserver, tenantId.get());
+    Streams.stream(entitiesCollection.search(DocStoreConverter.transform(tenantId.get(), request)))
+        .flatMap(
+            document -> PARSER.<Entity>parseOrLog(document, Entity.newBuilder()).stream())
+        .map(Entity::toBuilder)
+        .map(builder -> builder.setTenantId(tenantId.get()))
+        .map(Entity.Builder::build)
+        .forEach(responseObserver::onNext);
+
+    responseObserver.onCompleted();
   }
 
   @Override
@@ -611,30 +618,6 @@ public class EntityDataServiceImpl extends EntityDataServiceImplBase {
       responseObserver.onNext((T) builder.build());
       responseObserver.onCompleted();
     }
-  }
-
-  private void searchByQueryAndStreamResponse(
-      org.hypertrace.core.documentstore.Query query,
-      StreamObserver<Entity> responseObserver,
-      String tenantId) {
-
-    List<Entity> entities =
-        Streams.stream(entitiesCollection.search(query))
-               .flatMap(
-                   document ->
-                       PARSER
-                           .<Entity>parseOrLog(document, Entity.newBuilder())
-                           .stream())
-               .map(Entity::toBuilder)
-               .map(builder -> builder.setTenantId(tenantId))
-               .map(Entity.Builder::build)
-               .peek(responseObserver::onNext)
-               .collect(Collectors.toList());
-
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("Docstore query has returned the result: {}", entities);
-    }
-    responseObserver.onCompleted();
   }
 
   private void searchByQueryAndStreamRelationships(

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryServiceImpl.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryServiceImpl.java
@@ -20,6 +20,7 @@ import org.hypertrace.core.documentstore.Document;
 import org.hypertrace.core.documentstore.JSONDocument;
 import org.hypertrace.core.documentstore.SingleValueKey;
 import org.hypertrace.core.grpcutils.context.RequestContext;
+import org.hypertrace.entity.data.service.DocumentParser;
 import org.hypertrace.entity.data.service.v1.AttributeValue;
 import org.hypertrace.entity.data.service.v1.Entity;
 import org.hypertrace.entity.data.service.v1.Query;
@@ -49,6 +50,7 @@ public class EntityQueryServiceImpl extends EntityQueryServiceImplBase {
   private static final Logger LOG = LoggerFactory.getLogger(EntityQueryServiceImpl.class);
   private static final String ATTRIBUTE_MAP_CONFIG_PATH = "entity.service.attributeMap";
   private static final Parser PARSER = DocStoreJsonFormat.parser().ignoringUnknownFields();
+  private static final DocumentParser DOCUMENT_PARSER = new DocumentParser();
 
   private final Collection entitiesCollection;
   private final Map<String, Map<String, String>> attrNameToEDSAttrMap;
@@ -89,14 +91,30 @@ public class EntityQueryServiceImpl extends EntityQueryServiceImplBase {
         .convertToEDSQuery(request, attrNameToEDSAttrMap.get(request.getEntityType()));
     Iterator<Document> documentIterator = entitiesCollection.search(
         DocStoreConverter.transform(tenantId.get(), query));
-    List<Entity> entities = convertDocsToEntities(documentIterator);
 
-    //Build result
-    //TODO : chunk response. For now sending everything in one chunk
-    responseObserver.onNext(convertEntitiesToResultSetChunk(
-        entities,
-        request.getSelectionList(),
-        attrNameToEDSAttrMap.get(request.getEntityType())));
+    boolean isFirstEntity = true;
+    while (documentIterator.hasNext()) {
+      Optional<Entity> entity = DOCUMENT_PARSER.parseOrLog(documentIterator.next(), Entity.newBuilder());
+      if (entity.isPresent()) {
+        Row row = convertToEntityQueryResult(entity.get(), request.getSelectionList(), attrNameToEDSAttrMap.get(request.getEntityType()));
+        ResultSetChunk.Builder resultBuilder = ResultSetChunk.newBuilder();
+        // Set metadata for first entity
+        if (isFirstEntity) {
+          resultBuilder.setResultSetMetadata(ResultSetMetadata.newBuilder()
+              .addAllColumnMetadata(
+                  () -> request.getSelectionList().stream().map(Expression::getColumnIdentifier)
+                      .map(
+                          ColumnIdentifier::getColumnName)
+                      .map(s -> ColumnMetadata.newBuilder().setColumnName(s).build()).iterator())
+              .build());
+          isFirstEntity = false;
+        }
+        //Build data
+        resultBuilder.addRow(row);
+        responseObserver.onNext(resultBuilder.build());
+      }
+    }
+
     responseObserver.onCompleted();
   }
 

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryServiceImpl.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryServiceImpl.java
@@ -114,7 +114,6 @@ public class EntityQueryServiceImpl extends EntityQueryServiceImplBase {
         responseObserver.onNext(resultBuilder.build());
       }
     }
-
     responseObserver.onCompleted();
   }
 
@@ -133,7 +132,7 @@ public class EntityQueryServiceImpl extends EntityQueryServiceImplBase {
     return entities;
   }
 
-  private ResultSetChunk convertEntitiesToResultSetChunk(
+  private static ResultSetChunk convertEntitiesToResultSetChunk(
       List<Entity> entities,
       List<Expression> selections,
       Map<String, String> attributeFqnMapping) {
@@ -153,7 +152,7 @@ public class EntityQueryServiceImpl extends EntityQueryServiceImplBase {
     return resultBuilder.build();
   }
 
-  private Row convertToEntityQueryResult(
+  static Row convertToEntityQueryResult(
       Entity entity, List<Expression> selections, Map<String, String> egsToEdsAttrMapping) {
     Row.Builder result = Row.newBuilder();
     selections.stream()

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/EntityQueryConverterTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/EntityQueryConverterTest.java
@@ -1,9 +1,9 @@
 package org.hypertrace.entity.query.service;
 
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -11,9 +11,15 @@ import org.hypertrace.entity.data.service.v1.Query;
 import org.hypertrace.entity.query.service.v1.ColumnIdentifier;
 import org.hypertrace.entity.query.service.v1.EntityQueryRequest;
 import org.hypertrace.entity.query.service.v1.Expression;
+import org.hypertrace.entity.query.service.v1.Filter;
 import org.hypertrace.entity.query.service.v1.Function;
+import org.hypertrace.entity.query.service.v1.LiteralConstant;
+import org.hypertrace.entity.query.service.v1.Operator;
 import org.hypertrace.entity.query.service.v1.OrderByExpression;
 import org.hypertrace.entity.query.service.v1.SortOrder;
+import org.hypertrace.entity.query.service.v1.ValueType;
+import org.hypertrace.entity.v1.entitytype.EntityType;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -98,6 +104,29 @@ public class EntityQueryConverterTest {
     assertEquals(EDS_COLUMN_NAME1, convertedQuery.getOrderByList().get(0).getName());
     assertEquals(org.hypertrace.entity.data.service.v1.SortOrder.ASC,
         convertedQuery.getOrderBy(0).getOrder());
+  }
+
+  @Test
+  public void test_filter() {
+    EntityQueryRequest queryRequest = EntityQueryRequest.newBuilder()
+        .setEntityType(EntityType.SERVICE.name())
+        .setFilter(
+            Filter.newBuilder()
+                .setOperatorValue(Operator.LT.getNumber())
+                .setLhs(Expression.newBuilder().setColumnIdentifier(ColumnIdentifier.newBuilder().setColumnName("SERVICE.createdTime").build()).build())
+                .setRhs(Expression.newBuilder().setLiteral(
+                    LiteralConstant.newBuilder().setValue(
+                        org.hypertrace.entity.query.service.v1.Value.newBuilder()
+                            .setLong(Instant.now().toEpochMilli())
+                            .setValueType(ValueType.LONG)
+                            .build())
+                        .build()).
+                    build())
+                .build())
+        .build();
+    Query query = EntityQueryConverter.convertToEDSQuery(queryRequest, Map.of("SERVICE.createdTime", "createdTime"));
+    Assertions.assertEquals(EntityType.SERVICE.name(), query.getEntityType());
+    Assertions.assertNotNull(query.getFilter());
   }
 
   @Test

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/EntityQueryServiceImplTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/EntityQueryServiceImplTest.java
@@ -1,5 +1,6 @@
 package org.hypertrace.entity.query.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -8,45 +9,64 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.Lists;
+import com.google.protobuf.util.JsonFormat;
 import io.grpc.Context;
 import io.grpc.stub.StreamObserver;
+import java.time.Instant;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import org.hypertrace.core.documentstore.Collection;
+import org.hypertrace.core.documentstore.Document;
 import org.hypertrace.core.documentstore.JSONDocument;
 import org.hypertrace.core.documentstore.SingleValueKey;
 import org.hypertrace.core.grpcutils.context.RequestContext;
+import org.hypertrace.entity.data.service.v1.AttributeValue;
+import org.hypertrace.entity.data.service.v1.Entity;
+import org.hypertrace.entity.data.service.v1.Operator;
 import org.hypertrace.entity.query.service.v1.ColumnIdentifier;
+import org.hypertrace.entity.query.service.v1.EntityQueryRequest;
 import org.hypertrace.entity.query.service.v1.EntityUpdateRequest;
 import org.hypertrace.entity.query.service.v1.Expression;
+import org.hypertrace.entity.query.service.v1.Filter;
 import org.hypertrace.entity.query.service.v1.LiteralConstant;
 import org.hypertrace.entity.query.service.v1.LiteralConstant.Builder;
+import org.hypertrace.entity.query.service.v1.OrderByExpression;
 import org.hypertrace.entity.query.service.v1.ResultSetChunk;
+import org.hypertrace.entity.query.service.v1.Row;
 import org.hypertrace.entity.query.service.v1.SetAttribute;
 import org.hypertrace.entity.query.service.v1.UpdateOperation;
 import org.hypertrace.entity.query.service.v1.Value;
 import org.hypertrace.entity.query.service.v1.ValueType;
+import org.hypertrace.entity.service.constants.EntityServiceConstants;
 import org.hypertrace.entity.service.util.DocStoreJsonFormat;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
 
-public class EntityQueryServiceUpdateTest {
+public class EntityQueryServiceImplTest {
 
   private final Map<String, Map<String, String>> attributeFqnMaps = new HashMap<>();
-  private static final String TEST_ENTITY_NAME = "TEST_ENTITY";
+  private static final String TEST_ENTITY_TYPE = "TEST_ENTITY";
 
-  public EntityQueryServiceUpdateTest() {
+  private static final String EQS_COLUMN_NAME1 = "Entity.id";
+  private static final String EDS_COLUMN_NAME1 = "attributes.entity_id";
+  private static final String EQS_COLUMN_NAME2 = "Entity.status";
+  private static final String EDS_COLUMN_NAME2 = "attributes.status";
+
+  public EntityQueryServiceImplTest() {
     // Init attribute FQN mapping needed for tests here
     Map<String, String> entityAttributeFqnMap = new HashMap<>();
-    entityAttributeFqnMap.put("Entity.id", "attributes.entity_id");
-    entityAttributeFqnMap.put("Entity.status", "attributes.status");
+    entityAttributeFqnMap.put(EQS_COLUMN_NAME1, EDS_COLUMN_NAME1);
+    entityAttributeFqnMap.put(EQS_COLUMN_NAME2, EDS_COLUMN_NAME2);
 
-    attributeFqnMaps.put(TEST_ENTITY_NAME, entityAttributeFqnMap);
+    attributeFqnMaps.put(TEST_ENTITY_TYPE, entityAttributeFqnMap);
   }
 
   @Test
-  public void noTenantId() throws Exception {
+  public void testUpdate_noTenantId() throws Exception {
     StreamObserver<ResultSetChunk> mockResponseObserver = mock(StreamObserver.class);
 
     Context.current()
@@ -66,7 +86,7 @@ public class EntityQueryServiceUpdateTest {
   }
 
   @Test
-  public void noEntityType() throws Exception {
+  public void testUpdate_noEntityType() throws Exception {
     StreamObserver<ResultSetChunk> mockResponseObserver = mock(StreamObserver.class);
 
     Context.current()
@@ -86,7 +106,7 @@ public class EntityQueryServiceUpdateTest {
   }
 
   @Test
-  public void noEntityId() throws Exception {
+  public void testUpdate_noEntityId() throws Exception {
     StreamObserver<ResultSetChunk> mockResponseObserver = mock(StreamObserver.class);
 
     Context.current()
@@ -97,7 +117,7 @@ public class EntityQueryServiceUpdateTest {
                   new EntityQueryServiceImpl(mockEntitiesCollection(), attributeFqnMaps);
 
               eqs.update(EntityUpdateRequest.newBuilder()
-                  .setEntityType(TEST_ENTITY_NAME)
+                  .setEntityType(TEST_ENTITY_TYPE)
                   .build(), mockResponseObserver);
 
               verify(mockResponseObserver, times(1))
@@ -108,7 +128,7 @@ public class EntityQueryServiceUpdateTest {
   }
 
   @Test
-  public void noOperation() throws Exception {
+  public void testUpdate_noOperation() throws Exception {
     StreamObserver<ResultSetChunk> mockResponseObserver = mock(StreamObserver.class);
 
     Context.current()
@@ -119,7 +139,7 @@ public class EntityQueryServiceUpdateTest {
                   new EntityQueryServiceImpl(mockEntitiesCollection(), attributeFqnMaps);
 
               eqs.update(EntityUpdateRequest.newBuilder()
-                  .setEntityType(TEST_ENTITY_NAME)
+                  .setEntityType(TEST_ENTITY_TYPE)
                   .addEntityIds("entity-id-1")
                   .build(), mockResponseObserver);
 
@@ -131,7 +151,7 @@ public class EntityQueryServiceUpdateTest {
   }
 
   @Test
-  public void updateSuccess() throws Exception {
+  public void testUpdate_success() throws Exception {
     Collection mockEntitiesCollection = mockEntitiesCollection();
 
     Builder newStatus =
@@ -140,7 +160,7 @@ public class EntityQueryServiceUpdateTest {
 
     EntityUpdateRequest updateRequest =
         EntityUpdateRequest.newBuilder()
-            .setEntityType(TEST_ENTITY_NAME)
+            .setEntityType(TEST_ENTITY_TYPE)
             .addEntityIds("entity-id-1")
             .setOperation(
                 UpdateOperation.newBuilder()
@@ -175,6 +195,106 @@ public class EntityQueryServiceUpdateTest {
             eq(new SingleValueKey("tenant1", "entity-id-1")),
             eq("attributes.status"),
             eq(new JSONDocument(DocStoreJsonFormat.printer().print(newStatus))));
+  }
+
+  @Test
+  public void testExecute_noTenantId() throws Exception {
+    StreamObserver<ResultSetChunk> mockResponseObserver = mock(StreamObserver.class);
+
+    Context.current()
+        .withValue(RequestContext.CURRENT, mock(RequestContext.class))
+        .call(
+            () -> {
+              EntityQueryServiceImpl eqs =
+                  new EntityQueryServiceImpl(mockEntitiesCollection(), attributeFqnMaps);
+
+              eqs.execute(null, mockResponseObserver);
+
+              verify(mockResponseObserver, times(1))
+                  .onError(argThat(
+                      new ExceptionMessageMatcher("Tenant id is missing in the request.")));
+              return null;
+            });
+  }
+
+  @Test
+  public void testExecute_success() throws Exception {
+    Collection mockEntitiesCollection = mock(Collection.class);
+    Entity ENTITY =
+        Entity.newBuilder()
+            .setTenantId("tenant-1")
+            .setEntityType(TEST_ENTITY_TYPE)
+            .setEntityId(UUID.randomUUID().toString())
+            .setEntityName("Test entity")
+            .putAttributes(
+                EDS_COLUMN_NAME1,
+                AttributeValue.newBuilder().setValue(
+                    org.hypertrace.entity.data.service.v1.Value.newBuilder().setString("foo1")).build())
+            .build();
+
+    List<Document> docs = java.util.Collections.singletonList(new JSONDocument(JsonFormat.printer().print(ENTITY)));
+    when(mockEntitiesCollection.search(any())).thenReturn(docs.iterator());
+    EntityQueryRequest request = EntityQueryRequest.newBuilder()
+        .setEntityType(TEST_ENTITY_TYPE)
+        .addOrderBy(
+            OrderByExpression.newBuilder()
+                .setExpression(
+                    Expression.newBuilder().setColumnIdentifier(
+                        ColumnIdentifier.newBuilder()
+                            .setColumnName(EQS_COLUMN_NAME1)
+                            .build()))
+        ).build();
+    StreamObserver<ResultSetChunk> mockResponseObserver = mock(StreamObserver.class);
+    Context.current()
+        .withValue(RequestContext.CURRENT, mockRequestContextWithTenantId())
+        .call(
+            () -> {
+              EntityQueryServiceImpl eqs =
+                  new EntityQueryServiceImpl(mockEntitiesCollection, attributeFqnMaps);
+
+              eqs.execute(request, mockResponseObserver);
+              return null;
+            });
+
+    verify(mockEntitiesCollection, times(1)).search(any());
+    verify(mockResponseObserver, times(1)).onNext(any());
+    verify(mockResponseObserver, times(1)).onCompleted();
+  }
+
+  @Test
+  public void testConvertToEntityQueryResult() {
+    String entityId = UUID.randomUUID().toString();
+    String entityName = UUID.randomUUID().toString();
+    Entity entity =
+        Entity.newBuilder()
+            .setTenantId("tenant-1")
+            .setEntityType(TEST_ENTITY_TYPE)
+            .setEntityId(entityId)
+            .setEntityName(entityName)
+            .putAttributes(
+                "status",
+                AttributeValue.newBuilder().setValue(
+                    org.hypertrace.entity.data.service.v1.Value.newBuilder().setString("doing good")).build())
+            .build();
+
+    List<Expression> selections = Lists.newArrayList();
+    selections.add(Expression.newBuilder().setColumnIdentifier(
+        ColumnIdentifier.newBuilder().setColumnName("entity_id").build()).build());
+    selections.add(Expression.newBuilder().setColumnIdentifier(
+        ColumnIdentifier.newBuilder().setColumnName("entity_name").build()).build());
+    selections.add(Expression.newBuilder().setColumnIdentifier(
+        ColumnIdentifier.newBuilder().setColumnName("query_status").build()).build());
+
+    Row row = EntityQueryServiceImpl.convertToEntityQueryResult(
+        entity, selections,
+        Map.of(
+            "entity_id", EntityServiceConstants.ENTITY_ID,
+        "entity_name", EntityServiceConstants.ENTITY_NAME,
+        "query_status", "attributes.status"));
+
+    assertEquals(entityId, row.getColumn(0).getString());
+    assertEquals(entityName, row.getColumn(1).getString());
+    assertEquals("doing good", row.getColumn(2).getString());
   }
 
   private RequestContext mockRequestContextWithTenantId() {

--- a/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityQueryServiceTest.java
+++ b/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityQueryServiceTest.java
@@ -161,6 +161,36 @@ public class EntityQueryServiceTest {
     assertEquals(0, list.get(1).getResultSetMetadata().getColumnMetadataCount());
   }
 
+  @Test
+  public void testExecute_EmptyResponse() {
+    EntityQueryRequest queryRequestNoResult = EntityQueryRequest.newBuilder()
+        .setEntityType(EntityType.SERVICE.name())
+        .setFilter(
+            Filter.newBuilder()
+                .setOperatorValue(Operator.GT.getNumber())
+                .setLhs(Expression.newBuilder().setColumnIdentifier(ColumnIdentifier.newBuilder().setColumnName("SERVICE.createdTime").build()).build())
+                .setRhs(Expression.newBuilder().setLiteral(
+                    LiteralConstant.newBuilder().setValue(
+                        org.hypertrace.entity.query.service.v1.Value.newBuilder()
+                            .setLong(Instant.now().toEpochMilli())
+                            .setValueType(ValueType.LONG)
+                            .build())
+                        .build()).
+                    build())
+                .build())
+        .addSelection(Expression.newBuilder().setColumnIdentifier(ColumnIdentifier.newBuilder().setColumnName("SERVICE.id").build()).build())
+        .addSelection(Expression.newBuilder().setColumnIdentifier(ColumnIdentifier.newBuilder().setColumnName("SERVICE.name").build()).build())
+        .build();
+
+    Iterator<ResultSetChunk> resultSetChunkIterator = entityQueryServiceClient.execute(queryRequestNoResult, Map.of("x-tenant-id", TENANT_ID));
+    List<ResultSetChunk> list = Lists.newArrayList(resultSetChunkIterator);
+
+    assertEquals(1, list.size());
+    assertEquals(1, list.get(0).getChunkId());
+    assertTrue(list.get(0).getIsLastChunk());
+    assertTrue(list.get(0).getResultSetMetadata().getColumnMetadataCount() > 0);
+  }
+
   private AttributeValue generateRandomUUIDAttrValue() {
     return AttributeValue.newBuilder()
         .setValue(Value.newBuilder()

--- a/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityQueryServiceTest.java
+++ b/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityQueryServiceTest.java
@@ -1,0 +1,166 @@
+package org.hypertrace.entity.service.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.common.collect.Lists;
+import io.grpc.Channel;
+import io.grpc.ClientInterceptors;
+import io.grpc.ManagedChannelBuilder;
+import java.time.Instant;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.hypertrace.core.serviceframework.IntegrationTestServerUtil;
+import org.hypertrace.entity.constants.v1.CommonAttribute;
+import org.hypertrace.entity.data.service.client.EntityDataServiceClient;
+import org.hypertrace.entity.data.service.v1.AttributeValue;
+import org.hypertrace.entity.data.service.v1.Entity;
+import org.hypertrace.entity.data.service.v1.Value;
+import org.hypertrace.entity.query.service.client.EntityQueryServiceClient;
+import org.hypertrace.entity.query.service.v1.ColumnIdentifier;
+import org.hypertrace.entity.query.service.v1.EntityQueryRequest;
+import org.hypertrace.entity.query.service.v1.Expression;
+import org.hypertrace.entity.query.service.v1.Filter;
+import org.hypertrace.entity.query.service.v1.LiteralConstant;
+import org.hypertrace.entity.query.service.v1.Operator;
+import org.hypertrace.entity.query.service.v1.ResultSetChunk;
+import org.hypertrace.entity.query.service.v1.ValueType;
+import org.hypertrace.entity.service.client.config.EntityServiceClientConfig;
+import org.hypertrace.entity.service.client.config.EntityServiceTestConfig;
+import org.hypertrace.entity.service.constants.EntityConstants;
+import org.hypertrace.entity.type.client.EntityTypeServiceClient;
+import org.hypertrace.entity.type.service.v1.AttributeKind;
+import org.hypertrace.entity.type.service.v1.AttributeType;
+import org.hypertrace.entity.v1.entitytype.EntityType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link org.hypertrace.entity.query.service.client.EntityQueryServiceClient}
+ */
+public class EntityQueryServiceTest {
+
+  private static EntityQueryServiceClient entityQueryServiceClient;
+  private static EntityDataServiceClient entityDataServiceClient;
+  private static final String TENANT_ID =
+      "__testTenant__" + EntityQueryServiceClient.class.getSimpleName();
+  private static final String TEST_ENTITY_TYPE_V2 = "TEST_ENTITY";
+
+  @BeforeAll
+  public static void setUp() {
+    IntegrationTestServerUtil.startServices(new String[]{"entity-service"});
+    EntityServiceClientConfig esConfig = EntityServiceTestConfig.getClientConfig();
+    Channel channel = ClientInterceptors.intercept(ManagedChannelBuilder.forAddress(
+        esConfig.getHost(), esConfig.getPort()).usePlaintext().build());
+    entityQueryServiceClient = new EntityQueryServiceClient(channel);
+    entityDataServiceClient = new EntityDataServiceClient(channel);
+    setupEntityTypes(channel);
+  }
+
+  @AfterAll
+  public static void teardown() {
+    IntegrationTestServerUtil.shutdownServices();
+  }
+
+  private static void setupEntityTypes(Channel channel) {
+    org.hypertrace.entity.type.service.client.EntityTypeServiceClient entityTypeServiceV1Client
+        = new org.hypertrace.entity.type.service.client.EntityTypeServiceClient(channel);
+    EntityTypeServiceClient entityTypeServiceV2Client = new EntityTypeServiceClient(channel);
+    entityTypeServiceV1Client.upsertEntityType(
+        TENANT_ID,
+        org.hypertrace.entity.type.service.v1.EntityType.newBuilder()
+            .setName(EntityType.SERVICE.name())
+            .addAttributeType(
+                AttributeType.newBuilder()
+                    .setName(EntityConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_FQN))
+                    .setValueKind(AttributeKind.TYPE_STRING)
+                    .setIdentifyingAttribute(true)
+                    .build())
+            .build());
+  }
+
+  @Test
+  public void testExecute() {
+    // create and upsert some entities
+    Entity entity1 = Entity.newBuilder()
+        .setTenantId(TENANT_ID)
+        .setEntityType(EntityType.SERVICE.name())
+        .setEntityName("Some Service 1")
+        .putIdentifyingAttributes(
+            EntityConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_FQN),
+            generateRandomUUIDAttrValue())
+        .build();
+    Entity createdEntity1 = entityDataServiceClient.upsert(entity1);
+    assertNotNull(createdEntity1);
+    assertFalse(createdEntity1.getEntityId().trim().isEmpty());
+
+    Entity entity2 = Entity.newBuilder()
+        .setTenantId(TENANT_ID)
+        .setEntityType(EntityType.SERVICE.name())
+        .setEntityName("Some Service 2")
+        .putIdentifyingAttributes(
+            EntityConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_FQN),
+            generateRandomUUIDAttrValue())
+        .build();
+    Entity createdEntity2 = entityDataServiceClient.upsert(entity2);
+
+    EntityQueryRequest queryRequest = EntityQueryRequest.newBuilder()
+        .setEntityType(EntityType.SERVICE.name())
+        .setFilter(
+            Filter.newBuilder()
+                .setOperatorValue(Operator.LT.getNumber())
+                .setLhs(Expression.newBuilder().setColumnIdentifier(ColumnIdentifier.newBuilder().setColumnName("SERVICE.createdTime").build()).build())
+                .setRhs(Expression.newBuilder().setLiteral(
+                    LiteralConstant.newBuilder().setValue(
+                        org.hypertrace.entity.query.service.v1.Value.newBuilder()
+                            .setLong(Instant.now().toEpochMilli())
+                            .setValueType(ValueType.LONG)
+                            .build())
+                        .build()).
+                    build())
+                .build())
+        .addSelection(Expression.newBuilder().setColumnIdentifier(ColumnIdentifier.newBuilder().setColumnName("SERVICE.id").build()).build())
+        .addSelection(Expression.newBuilder().setColumnIdentifier(ColumnIdentifier.newBuilder().setColumnName("SERVICE.name").build()).build())
+        .build();
+
+    // this entity will be filtered out
+    Entity entity3 = Entity.newBuilder()
+        .setTenantId(TENANT_ID)
+        .setEntityType(EntityType.SERVICE.name())
+        .setEntityName("Some Service 2")
+        .putIdentifyingAttributes(
+            EntityConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_FQN),
+            generateRandomUUIDAttrValue())
+        .build();
+    entityDataServiceClient.upsert(entity3);
+
+    Iterator<ResultSetChunk> resultSetChunkIterator = entityQueryServiceClient.execute(queryRequest, Map.of("x-tenant-id", TENANT_ID));
+    List<ResultSetChunk> list = Lists.newArrayList(resultSetChunkIterator);
+    assertEquals(2, list.size());
+    // chunk size is always 1
+    assertEquals(1, list.get(0).getRowCount());
+    assertEquals(1, list.get(1).getRowCount());
+
+    assertEquals(createdEntity1.getEntityId(), list.get(0).getRow(0).getColumn(0).getString());
+    assertEquals(createdEntity1.getEntityName(), list.get(0).getRow(0).getColumn(1).getString());
+    assertEquals(createdEntity2.getEntityId(), list.get(1).getRow(0).getColumn(0).getString());
+    assertEquals(createdEntity2.getEntityName(), list.get(1).getRow(0).getColumn(1).getString());
+
+    // metadata sent for first chunk
+    assertTrue(list.get(0).getResultSetMetadata().getColumnMetadataCount() > 0);
+    assertEquals(0, list.get(1).getResultSetMetadata().getColumnMetadataCount());
+  }
+
+  private AttributeValue generateRandomUUIDAttrValue() {
+    return AttributeValue.newBuilder()
+        .setValue(Value.newBuilder()
+            .setString(UUID.randomUUID().toString())
+            .build())
+        .build();
+  }
+}

--- a/entity-service/src/integrationTest/resources/configs/entity-service/application.conf
+++ b/entity-service/src/integrationTest/resources/configs/entity-service/application.conf
@@ -11,5 +11,20 @@ entity.service.config = {
     }
   }
 }
-# This should be completely driven based on config given in app packaging.
-entity.service.attributeMap = []
+entity.service.attributeMap = [
+  {
+    "scope": "SERVICE",
+    "name": "SERVICE.id",
+    "subDocPath": "entityId"
+  },
+  {
+    "scope": "SERVICE",
+    "name": "SERVICE.name",
+    "subDocPath": "entityName"
+  },
+  {
+    "scope": "SERVICE",
+    "name": "SERVICE.createdTime",
+    "subDocPath": "createdTime"
+  }
+]


### PR DESCRIPTION
## Description
https://github.com/hypertrace/entity-service/issues/56
The change is to correctly stream the data from the query apis, so that client doesn't face a data overload. 

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Added integration test 