### PR TITLE
fix: proto command run instead of uses

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -59,7 +59,7 @@ jobs:
           fetch-depth: 0
 
       - name: verify-protos
-        uses: buf check lint
+        run: buf check lint
 
   validate-helm-charts:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
## Description
uses `run` instead of `uses` for proto validation job in GHA. 