### PR TITLE
chore: bump doc-store version to include SQLi fix

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,5 +5,5 @@ ignore:
   SNYK-JAVA-IONETTY-1042268:
     - '*':
         reason: None Given
-        expires: 2021-01-31T00:00:00.000Z
+        expires: 2021-02-28T00:00:00.000Z
 patch: {}

--- a/entity-service-impl/build.gradle.kts
+++ b/entity-service-impl/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 dependencies {
   api(project(":entity-service-api"))
   api("org.hypertrace.core.serviceframework:service-framework-spi:0.1.19")
-  implementation("org.hypertrace.core.documentstore:document-store:0.5.0")
+  implementation("org.hypertrace.core.documentstore:document-store:0.5.1")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.3.1")
   implementation(project(":entity-type-service-rx-client"))
 

--- a/entity-service/build.gradle.kts
+++ b/entity-service/build.gradle.kts
@@ -59,7 +59,7 @@ dependencies {
   implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.3.1")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.3.1")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.19")
-  implementation("org.hypertrace.core.documentstore:document-store:0.5.0")
+  implementation("org.hypertrace.core.documentstore:document-store:0.5.1")
 
   runtimeOnly("io.grpc:grpc-netty:1.33.1")
   constraints {


### PR DESCRIPTION
- Updates doc-store version to include SQLi fix - hypertrace/document-store#30
- extends expiry for ionetty vulnerability