### PR TITLE
fix:addresses not_in filter query for array type field - attributes.lables

### DIFF
--- a/entity-service-impl/build.gradle.kts
+++ b/entity-service-impl/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 dependencies {
   api(project(":entity-service-api"))
   api("org.hypertrace.core.serviceframework:service-framework-spi:0.1.19")
-  implementation("org.hypertrace.core.documentstore:document-store:0.5.1")
+  implementation("org.hypertrace.core.documentstore:document-store:0.5.2")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.3.1")
   implementation(project(":entity-type-service-rx-client"))
 

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/service/util/DocStoreConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/service/util/DocStoreConverter.java
@@ -194,16 +194,10 @@ public class DocStoreConverter {
     f.setFieldName("");
     f.setOp(Op.AND);
 
-    Filter exists = new Filter();
-    exists.setFieldName(fieldName);
-    exists.setOp(Op.EXISTS);
-    exists.setValue(true);
-
     List<Filter> filters = attributeFilter.getAttributeValue().getValueList().getValuesList().stream()
         .map(rhsAttributeValue -> createNeqFilterForAttributeValue(fieldName, rhsAttributeValue))
         .collect(Collectors.toList());
 
-    filters.add(exists);
     f.setChildFilters(filters.toArray(new Filter[]{}));
 
     return f;
@@ -216,27 +210,12 @@ public class DocStoreConverter {
 
   private static Filter transformToNeqFilterWithValueListRhs(AttributeFilter attributeFilter) {
     String fieldName = attributeFilter.getName() + VALUE_LIST_VALUES_CONST;
-
     Filter f = new Filter();
-    f.setFieldName("");
-    f.setOp(Op.AND);
-
-    Filter [] childFilters = new Filter[2];
-
-    Filter exists = new Filter();
-    exists.setFieldName(fieldName);
-    exists.setOp(Op.EXISTS);
-    exists.setValue(true);
-    childFilters[0] = exists;
-
-    Filter neq = new Filter();
-    neq.setFieldName(fieldName);
-    neq.setOp(Op.NEQ);
-    neq.setValue(prepareRhsValueForSpecialValueListCase(attributeFilter.getAttributeValue()));
-    childFilters[1] = neq;
-
+    f.setFieldName(fieldName);
+    f.setOp(Op.NEQ);
+    f.setValue(prepareRhsValueForSpecialValueListCase(attributeFilter.getAttributeValue()));
     // Set child filters to empty array
-    f.setChildFilters(childFilters);
+    f.setChildFilters(new Filter[]{});
     return f;
   }
 

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/service/util/DocStoreConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/service/util/DocStoreConverter.java
@@ -192,12 +192,17 @@ public class DocStoreConverter {
     f.setFieldName("");
     f.setOp(Op.AND);
 
-    f.setChildFilters(
-        attributeFilter.getAttributeValue().getValueList().getValuesList().stream()
-            .map(rhsAttributeValue -> createNeqFilterForAttributeValue(fieldName, rhsAttributeValue))
-            .collect(Collectors.toList())
-            .toArray(new Filter[]{})
-    );
+    Filter exists = new Filter();
+    exists.setFieldName(fieldName);
+    exists.setOp(Op.EXISTS);
+    exists.setValue(true);
+
+    List<Filter> filters = attributeFilter.getAttributeValue().getValueList().getValuesList().stream()
+        .map(rhsAttributeValue -> createNeqFilterForAttributeValue(fieldName, rhsAttributeValue))
+        .collect(Collectors.toList());
+
+    filters.add(exists);
+    f.setChildFilters(filters.toArray(new Filter[]{}));
 
     return f;
   }

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/service/util/DocStoreConverterTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/service/util/DocStoreConverterTest.java
@@ -627,6 +627,12 @@ public class DocStoreConverterTest {
     Assertions.assertEquals(Op.NEQ, transformedFilter.getChildFilters()[2].getChildFilters()[1].getChildFilters()[2].getOp());
     Assertions.assertEquals(OBJECT_MAPPER.convertValue(OBJECT_MAPPER.readTree("{\"value\": {\"string\":\"l3\"}}"), Map.class),
         transformedFilter.getChildFilters()[2].getChildFilters()[1].getChildFilters()[2].getValue());
+
+    Assertions.assertEquals(ATTRIBUTES_LABELS_FIELD_NAME + ".valueList.values",
+        transformedFilter.getChildFilters()[2].getChildFilters()[1].getChildFilters()[3].getFieldName());
+    Assertions.assertEquals(Op.EXISTS, transformedFilter.getChildFilters()[2].getChildFilters()[1].getChildFilters()[3].getOp());
+    Assertions.assertEquals(true,
+        transformedFilter.getChildFilters()[2].getChildFilters()[1].getChildFilters()[3].getValue());
   }
 
   @Test

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/service/util/DocStoreConverterTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/service/util/DocStoreConverterTest.java
@@ -518,26 +518,16 @@ public class DocStoreConverterTest {
     Assertions.assertEquals(Op.AND, transformedFilter.getChildFilters()[2].getOp());
 
     Assertions.assertEquals(ATTRIBUTES_LABELS_FIELD_NAME + ".valueList.values",
-        transformedFilter.getChildFilters()[2].getChildFilters()[0].getChildFilters()[0].getFieldName());
-    Assertions.assertEquals(Op.EXISTS, transformedFilter.getChildFilters()[2].getChildFilters()[0].getChildFilters()[0].getOp());
-    Assertions.assertEquals(true, transformedFilter.getChildFilters()[2].getChildFilters()[0].getChildFilters()[0].getValue());
-
-    Assertions.assertEquals(ATTRIBUTES_LABELS_FIELD_NAME + ".valueList.values",
-        transformedFilter.getChildFilters()[2].getChildFilters()[0].getChildFilters()[1].getFieldName());
-    Assertions.assertEquals(Op.NEQ, transformedFilter.getChildFilters()[2].getChildFilters()[0].getChildFilters()[1].getOp());
+        transformedFilter.getChildFilters()[2].getChildFilters()[0].getFieldName());
+    Assertions.assertEquals(Op.NEQ, transformedFilter.getChildFilters()[2].getChildFilters()[0].getOp());
     Assertions.assertEquals(OBJECT_MAPPER.convertValue(OBJECT_MAPPER.readTree("{\"value\": {\"string\":\"l1\"}}"), Map.class),
-        transformedFilter.getChildFilters()[2].getChildFilters()[0].getChildFilters()[1].getValue());
+        transformedFilter.getChildFilters()[2].getChildFilters()[0].getValue());
 
     Assertions.assertEquals(ATTRIBUTES_LABELS_FIELD_NAME + ".valueList.values",
-        transformedFilter.getChildFilters()[2].getChildFilters()[1].getChildFilters()[0].getFieldName());
-    Assertions.assertEquals(Op.EXISTS, transformedFilter.getChildFilters()[2].getChildFilters()[1].getChildFilters()[0].getOp());
-    Assertions.assertEquals(true, transformedFilter.getChildFilters()[2].getChildFilters()[1].getChildFilters()[0].getValue());
-
-    Assertions.assertEquals(ATTRIBUTES_LABELS_FIELD_NAME + ".valueList.values",
-        transformedFilter.getChildFilters()[2].getChildFilters()[1].getChildFilters()[1].getFieldName());
-    Assertions.assertEquals(Op.NEQ, transformedFilter.getChildFilters()[2].getChildFilters()[1].getChildFilters()[1].getOp());
+        transformedFilter.getChildFilters()[2].getChildFilters()[1].getFieldName());
+    Assertions.assertEquals(Op.NEQ, transformedFilter.getChildFilters()[2].getChildFilters()[1].getOp());
     Assertions.assertEquals(OBJECT_MAPPER.convertValue(OBJECT_MAPPER.readTree("{\"value\": {\"string\":\"l2\"}}"), Map.class),
-        transformedFilter.getChildFilters()[2].getChildFilters()[1].getChildFilters()[1].getValue());
+        transformedFilter.getChildFilters()[2].getChildFilters()[1].getValue());
   }
 
   @Test
@@ -688,12 +678,6 @@ public class DocStoreConverterTest {
     Assertions.assertEquals(Op.NEQ, transformedFilter.getChildFilters()[2].getChildFilters()[1].getChildFilters()[2].getOp());
     Assertions.assertEquals(OBJECT_MAPPER.convertValue(OBJECT_MAPPER.readTree("{\"value\": {\"string\":\"l3\"}}"), Map.class),
         transformedFilter.getChildFilters()[2].getChildFilters()[1].getChildFilters()[2].getValue());
-
-    Assertions.assertEquals(ATTRIBUTES_LABELS_FIELD_NAME + ".valueList.values",
-        transformedFilter.getChildFilters()[2].getChildFilters()[1].getChildFilters()[3].getFieldName());
-    Assertions.assertEquals(Op.EXISTS, transformedFilter.getChildFilters()[2].getChildFilters()[1].getChildFilters()[3].getOp());
-    Assertions.assertEquals(true,
-        transformedFilter.getChildFilters()[2].getChildFilters()[1].getChildFilters()[3].getValue());
   }
 
   @Test

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/service/util/DocStoreConverterTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/service/util/DocStoreConverterTest.java
@@ -480,6 +480,67 @@ public class DocStoreConverterTest {
   }
 
   @Test
+  public void testStringArrayValueTypeColumnNeqAndChain() throws JsonProcessingException {
+    Query query = Query.newBuilder()
+        .addEntityId("some id")
+        .setFilter(
+            AttributeFilter.newBuilder().setOperator(Operator.AND)
+                .addChildFilter(
+                    AttributeFilter.newBuilder()
+                        .setName(ATTRIBUTES_LABELS_FIELD_NAME)
+                        .setOperator(Operator.NEQ)
+                        .setAttributeValue(AttributeValue.newBuilder()
+                            .setValue(Value.newBuilder().setString("l1"))
+                        )
+                )
+                .addChildFilter(
+                    AttributeFilter.newBuilder()
+                        .setName(ATTRIBUTES_LABELS_FIELD_NAME)
+                        .setOperator(Operator.NEQ)
+                        .setAttributeValue(AttributeValue.newBuilder()
+                            .setValue(Value.newBuilder().setString("l2"))
+                        )
+                )
+        )
+        .build();
+    org.hypertrace.core.documentstore.Query transformedQuery =
+        DocStoreConverter.transform(TENANT_ID, query, Collections.emptyList());
+
+    Filter transformedFilter = transformedQuery.getFilter();
+    Assertions.assertEquals(Filter.Op.AND, transformedFilter.getOp());
+
+    Assertions.assertEquals(3, transformedFilter.getChildFilters().length);
+    Assertions.assertEquals(EntityServiceConstants.ENTITY_ID,
+        transformedFilter.getChildFilters()[1].getFieldName());
+    Assertions.assertEquals(Collections.singletonList("some id"),
+        transformedFilter.getChildFilters()[1].getValue());
+
+    Assertions.assertEquals(Op.AND, transformedFilter.getChildFilters()[2].getOp());
+
+    Assertions.assertEquals(ATTRIBUTES_LABELS_FIELD_NAME + ".valueList.values",
+        transformedFilter.getChildFilters()[2].getChildFilters()[0].getChildFilters()[0].getFieldName());
+    Assertions.assertEquals(Op.EXISTS, transformedFilter.getChildFilters()[2].getChildFilters()[0].getChildFilters()[0].getOp());
+    Assertions.assertEquals(true, transformedFilter.getChildFilters()[2].getChildFilters()[0].getChildFilters()[0].getValue());
+
+    Assertions.assertEquals(ATTRIBUTES_LABELS_FIELD_NAME + ".valueList.values",
+        transformedFilter.getChildFilters()[2].getChildFilters()[0].getChildFilters()[1].getFieldName());
+    Assertions.assertEquals(Op.NEQ, transformedFilter.getChildFilters()[2].getChildFilters()[0].getChildFilters()[1].getOp());
+    Assertions.assertEquals(OBJECT_MAPPER.convertValue(OBJECT_MAPPER.readTree("{\"value\": {\"string\":\"l1\"}}"), Map.class),
+        transformedFilter.getChildFilters()[2].getChildFilters()[0].getChildFilters()[1].getValue());
+
+    Assertions.assertEquals(ATTRIBUTES_LABELS_FIELD_NAME + ".valueList.values",
+        transformedFilter.getChildFilters()[2].getChildFilters()[1].getChildFilters()[0].getFieldName());
+    Assertions.assertEquals(Op.EXISTS, transformedFilter.getChildFilters()[2].getChildFilters()[1].getChildFilters()[0].getOp());
+    Assertions.assertEquals(true, transformedFilter.getChildFilters()[2].getChildFilters()[1].getChildFilters()[0].getValue());
+
+    Assertions.assertEquals(ATTRIBUTES_LABELS_FIELD_NAME + ".valueList.values",
+        transformedFilter.getChildFilters()[2].getChildFilters()[1].getChildFilters()[1].getFieldName());
+    Assertions.assertEquals(Op.NEQ, transformedFilter.getChildFilters()[2].getChildFilters()[1].getChildFilters()[1].getOp());
+    Assertions.assertEquals(OBJECT_MAPPER.convertValue(OBJECT_MAPPER.readTree("{\"value\": {\"string\":\"l2\"}}"), Map.class),
+        transformedFilter.getChildFilters()[2].getChildFilters()[1].getChildFilters()[1].getValue());
+  }
+
+  @Test
   public void testStringArrayValueTypeColumnOrChain() throws JsonProcessingException {
     Query query = Query.newBuilder()
         .addEntityId("some id")

--- a/entity-service/build.gradle.kts
+++ b/entity-service/build.gradle.kts
@@ -59,7 +59,7 @@ dependencies {
   implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.3.1")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.3.1")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.19")
-  implementation("org.hypertrace.core.documentstore:document-store:0.5.1")
+  implementation("org.hypertrace.core.documentstore:document-store:0.5.2")
 
   runtimeOnly("io.grpc:grpc-netty:1.33.1")
   runtimeOnly("io.netty:netty-codec-http2:4.1.59.Final")

--- a/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityDataServiceTest.java
+++ b/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityDataServiceTest.java
@@ -874,6 +874,99 @@ public class EntityDataServiceTest {
 
   }
 
+  @Test
+  public void testNotInFilterForMatchingLabelsQuery() {
+    Entity entity = createEntityWithAttributeLabels("Some Service 1",
+        List.of("v1", "v2", "v3"));
+    Entity createdEntity1 = entityDataServiceClient.upsert(entity);
+    assertNotNull(createdEntity1);
+    assertNotNull(createdEntity1.getEntityId().trim());
+
+    entity = createEntityWithAttributeLabels("Some Service 2",
+        List.of("v01", "v02", "v03"));
+    Entity createdEntity2 = entityDataServiceClient.upsert(entity);
+    assertNotNull(createdEntity2);
+    assertNotNull(createdEntity2.getEntityId().trim());
+
+    entity = createEntityWithAttributeLabels("Some Service 3",
+        List.of("v01", "v2", "v4"));
+    Entity createdEntity3 = entityDataServiceClient.upsert(entity);
+    assertNotNull(createdEntity3);
+    assertNotNull(createdEntity3.getEntityId().trim());
+
+    entity = createEntityWithAttributeLabels("Some Service 4",
+        List.of("b1", "b2", "b3"));
+    Entity createdEntity4 = entityDataServiceClient.upsert(entity);
+    assertNotNull(createdEntity4);
+    assertNotNull(createdEntity4.getEntityId().trim());
+
+    entity = createEntityWithOutAttributeLabels("Some Service 5",
+        "foo", "bar");
+    Entity createdEntity5 = entityDataServiceClient.upsert(entity);
+    assertNotNull(createdEntity5);
+    assertNotNull(createdEntity5.getEntityId().trim());
+
+    AttributeFilter attributeFilter = AttributeFilter.newBuilder()
+        .setName("attributes.labels")
+        .setOperator(Operator.NOT_IN)
+        .setAttributeValue(AttributeValue.newBuilder()
+            .setValueList(
+                AttributeValueList.newBuilder()
+                    .addValues(
+                        AttributeValue.newBuilder().setValue(Value.newBuilder().setString("b1"))
+                    )
+                    .addValues(
+                        AttributeValue.newBuilder().setValue(Value.newBuilder().setString("v4"))
+                    )
+            )
+        ).build();
+
+    Query query = Query.newBuilder()
+        .setEntityType(EntityType.K8S_POD.name())
+        .setFilter(attributeFilter).build();
+    List<Entity> entitiesList = entityDataServiceClient.query(TENANT_ID, query);
+    assertTrue(entitiesList.size() == 2);
+    assertTrue(entitiesList.contains(createdEntity1) && entitiesList.contains(createdEntity2));
+  }
+
+  private Entity createEntityWithAttributeLabels(String entityName, List<String> labels) {
+    AttributeValueList.Builder listBuilder = AttributeValueList.newBuilder();
+    labels.forEach(label -> listBuilder.addValues(
+          AttributeValue.newBuilder().setValue(Value.newBuilder().setString(label)))
+    );
+    AttributeValue value = AttributeValue.newBuilder().setValueList(listBuilder.build()).build();
+
+    Entity entity = Entity.newBuilder()
+        .setTenantId(TENANT_ID)
+        .setEntityType(EntityType.K8S_POD.name())
+        .setEntityName(entityName)
+        .putIdentifyingAttributes(
+            EntityConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_EXTERNAL_ID),
+            generateRandomUUIDAttrValue())
+        .putAttributes(
+            "labels", value)
+        .build();
+
+    return entity;
+  }
+
+  private Entity createEntityWithOutAttributeLabels(String entityName, String attrName, String attrValue) {
+    Entity entity = Entity.newBuilder()
+        .setTenantId(TENANT_ID)
+        .setEntityType(EntityType.K8S_POD.name())
+        .setEntityName(entityName)
+        .putIdentifyingAttributes(
+            EntityConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_EXTERNAL_ID),
+            generateRandomUUIDAttrValue())
+        .putAttributes(
+            attrName,
+            AttributeValue.newBuilder()
+                .setValue(Value.newBuilder().setString(attrValue).build())
+                .build())
+        .build();
+    return entity;
+  }
+
   private AttributeValue generateRandomUUIDAttrValue() {
     return AttributeValue.newBuilder()
         .setValue(Value.newBuilder()

--- a/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityDataServiceTest.java
+++ b/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityDataServiceTest.java
@@ -952,6 +952,32 @@ public class EntityDataServiceTest {
     assertTrue(entitiesList.size() == 2);
     assertTrue(entitiesList.contains(createdEntity3) && entitiesList.contains(createdEntity4));
 
+    // test NEQ
+    attributeFilter = AttributeFilter.newBuilder().setOperator(Operator.AND)
+        .addChildFilter(
+            AttributeFilter.newBuilder()
+                .setName("attributes.labels")
+                .setOperator(Operator.NEQ)
+                .setAttributeValue(AttributeValue.newBuilder()
+                    .setValue(Value.newBuilder().setString("v2"))
+                )
+        )
+        .addChildFilter(
+            AttributeFilter.newBuilder()
+                .setName("attributes.labels")
+                .setOperator(Operator.NEQ)
+                .setAttributeValue(AttributeValue.newBuilder()
+                    .setValue(Value.newBuilder().setString("b1"))
+                )
+        ).build();
+
+    query = Query.newBuilder().setEntityType(EntityType.K8S_POD.name()).setFilter(attributeFilter)
+        .build();
+    entitiesList = entityDataServiceClient.query(TENANT_ID, query);
+    assertTrue(entitiesList.size() == 1);
+    assertTrue(entitiesList.contains(createdEntity2));
+
+
     // test EQ
     attributeFilter = AttributeFilter.newBuilder()
         .setName("attributes.labels")
@@ -964,7 +990,9 @@ public class EntityDataServiceTest {
         .build();
     entitiesList = entityDataServiceClient.query(TENANT_ID, query);
     assertTrue(entitiesList.size() == 2);
-    assertTrue(entitiesList.contains(createdEntity1) && entitiesList.contains(createdEntity3));
+    assertTrue(entitiesList.contains(createdEntity1)
+        && entitiesList.contains(createdEntity3));
+
   }
 
   private Entity createEntityWithAttributeLabels(String entityName, List<String> labels) {

--- a/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityDataServiceTest.java
+++ b/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityDataServiceTest.java
@@ -977,7 +977,7 @@ public class EntityDataServiceTest {
         .build();
     entitiesList = entityDataServiceClient.query(TENANT_ID, query);
     assertTrue(entitiesList.size() == 2);
-    assertTrue(entitiesList.contains(createdEntity2) && entitiesList.contains(createdEntity2));
+    assertTrue(entitiesList.contains(createdEntity2) && entitiesList.contains(createdEntity5));
 
 
     // test EQ

--- a/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityDataServiceTest.java
+++ b/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityDataServiceTest.java
@@ -927,8 +927,10 @@ public class EntityDataServiceTest {
         .setEntityType(EntityType.K8S_POD.name())
         .setFilter(attributeFilter).build();
     List<Entity> entitiesList = entityDataServiceClient.query(TENANT_ID, query);
-    assertTrue(entitiesList.size() == 2);
-    assertTrue(entitiesList.contains(createdEntity1) && entitiesList.contains(createdEntity2));
+    assertTrue(entitiesList.size() == 3);
+    assertTrue(entitiesList.contains(createdEntity1)
+        && entitiesList.contains(createdEntity2)
+        && entitiesList.contains(createdEntity5));
 
     // test IN
     attributeFilter = AttributeFilter.newBuilder()
@@ -974,8 +976,8 @@ public class EntityDataServiceTest {
     query = Query.newBuilder().setEntityType(EntityType.K8S_POD.name()).setFilter(attributeFilter)
         .build();
     entitiesList = entityDataServiceClient.query(TENANT_ID, query);
-    assertTrue(entitiesList.size() == 1);
-    assertTrue(entitiesList.contains(createdEntity2));
+    assertTrue(entitiesList.size() == 2);
+    assertTrue(entitiesList.contains(createdEntity2) && entitiesList.contains(createdEntity2));
 
 
     // test EQ


### PR DESCRIPTION
## Description
This PR addresses a gap for the handling of searching entities for not matching labels for array type field `attributes.labels` 
Currently, we have support for searching entities for matching labels, but we need similar capabilities to search entities for not matching labels. 

Currently, filtering entities for matching labels `attributes.labels IN (<val1> , <val2>)` is translated to `attributes.labels = <val1> OR attributes.labels = <val2> 
This PR adds support for `attributes.labels NOT_IN (<val1> , <val2>)` by translating it into `attributes.labels != <val1> AND attributes.labels != <val2>` 

### Testing
- added unit tests
- verified locally running MongoDB with the following data and query

Data:
```
db.mytest.insertOne(
   { item: "canvas", qty: 100, attributes: {labels: { valueList : {"values":[{"value":{"string":"attr-v1"}},{"value":{"string":"attr-v2"}},{"value":{"string":"attr-v3"}}]}} }}
)

db.mytest.insertOne(
   { item: "canvas", qty: 100, attributes: {labels: { valueList : {"values":[{"value":{"string":"attr-v01"}},{"value":{"string":"attr-v02"}},{"value":{"string":"attr-v03"}}]}} }}
)

db.mytest.insertOne(
   { item: "canvas", qty: 100, attributes: {labels: { valueList : {"values":[{"value":{"string":"attr-v01"}},{"value":{"string":"attr-v2"}},{"value":{"string":"attr-v4"}}]}} }}
)

db.mytest.insertOne(
   { item: "canvas", qty: 100, attributes: {labels: { valueList : {"values":[{"value":{"string":"attr-b1"}},{"value":{"string":"attr-b2"}},{"value":{"string":"attr-b4"}}]}} }}
)
```
Query:
```
db.mytest.find( { $and: [ {'attributes.labels.valueList.values': { $ne: {"value":{"string":"attr-b1"}}}}, {'attributes.labels.valueList.values': { $ne: {"value":{"string":"attr-v4"}}}}] } )
```

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
None

### Note
We have a ticket for adding `NOT_IN` filter support in docstore interface - https://github.com/hypertrace/document-store/issues/32