### PR TITLE
chore: bump doc-store version to include postgres impl of exits, not-exsits and neq

### DIFF
--- a/entity-service-impl/build.gradle.kts
+++ b/entity-service-impl/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 dependencies {
   api(project(":entity-service-api"))
   api("org.hypertrace.core.serviceframework:service-framework-spi:0.1.19")
-  implementation("org.hypertrace.core.documentstore:document-store:0.5.2")
+  implementation("org.hypertrace.core.documentstore:document-store:0.5.3")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.3.1")
   implementation(project(":entity-type-service-rx-client"))
 

--- a/entity-service/build.gradle.kts
+++ b/entity-service/build.gradle.kts
@@ -59,7 +59,7 @@ dependencies {
   implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.3.1")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.3.1")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.19")
-  implementation("org.hypertrace.core.documentstore:document-store:0.5.2")
+  implementation("org.hypertrace.core.documentstore:document-store:0.5.3")
 
   runtimeOnly("io.grpc:grpc-netty:1.33.1")
   runtimeOnly("io.netty:netty-codec-http2:4.1.59.Final")


### PR DESCRIPTION
Updates doc-store version to include postgres impl of exists, not-exists, and NEQ filters 
- https://github.com/hypertrace/document-store/pull/35
- https://github.com/hypertrace/document-store/pull/33