### PR TITLE
fix: support working with v2 typed entities

### DIFF
--- a/entity-service-api/src/main/proto/org/hypertrace/entity/data/service/v1/entity_data_request.proto
+++ b/entity-service-api/src/main/proto/org/hypertrace/entity/data/service/v1/entity_data_request.proto
@@ -8,6 +8,7 @@ import "org/hypertrace/entity/data/service/v1/enriched_entity.proto";
 
 message ByIdRequest {
   string entity_id = 2;
+  string entity_type = 3;
 }
 
 message ByTypeAndIdentifyingAttributes {

--- a/entity-service-api/src/main/proto/org/hypertrace/entity/data/service/v1/entity_data_service.proto
+++ b/entity-service-api/src/main/proto/org/hypertrace/entity/data/service/v1/entity_data_service.proto
@@ -12,7 +12,8 @@ service EntityDataService {
   }
   rpc upsertEntities (Entities) returns (Empty) {
   }
-  rpc getAndUpsertEntities (Entities) returns (stream Entity) {}
+  rpc getAndUpsertEntities (Entities) returns (stream Entity) {
+  }
   rpc delete (ByIdRequest) returns (Empty) {
   }
   rpc getById (ByIdRequest) returns (Entity) {

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/data/service/EntityV2TypeDocKey.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/data/service/EntityV2TypeDocKey.java
@@ -1,0 +1,36 @@
+package org.hypertrace.entity.data.service;
+
+import java.util.Objects;
+import org.hypertrace.core.documentstore.Key;
+
+class EntityV2TypeDocKey implements Key {
+  private final String tenantId;
+  private final String entityType;
+  private final String entityId;
+
+  EntityV2TypeDocKey(String tenantId, String entityType, String entityId) {
+    this.tenantId = tenantId;
+    this.entityType = entityType;
+    this.entityId = entityId;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s:%s:%s", this.tenantId, this.entityType, this.entityId);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    EntityV2TypeDocKey that = (EntityV2TypeDocKey) o;
+    return Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(entityType, that.entityType)
+        && Objects.equals(entityId, that.entityId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(tenantId, entityType, entityId);
+  }
+}

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/data/service/EntityNormalizerTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/data/service/EntityNormalizerTest.java
@@ -193,6 +193,18 @@ class EntityNormalizerTest {
                 .build()));
   }
 
+  @Test
+  void returnsSimpleKeyIfNoEntityTypeProvided() {
+    assertEquals(
+        new SingleValueKey(TENANT_ID, "id-in"),
+        this.normalizer.getEntityDocKey(TENANT_ID, "", "id-in"));
+
+    assertEquals(
+        new SingleValueKey(TENANT_ID, "id-in"),
+        this.normalizer.getEntityDocKey(
+            TENANT_ID, Entity.newBuilder().setEntityId("id-in").build()));
+  }
+
   private Map<String, AttributeValue> buildValueMap(Map<String, String> stringMap) {
     return stringMap.entrySet().stream()
         .map(

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/data/service/EntityV2TypeDocKeyTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/data/service/EntityV2TypeDocKeyTest.java
@@ -1,0 +1,16 @@
+package org.hypertrace.entity.data.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.hypertrace.core.documentstore.Key;
+import org.junit.jupiter.api.Test;
+
+class EntityV2TypeDocKeyTest {
+
+  @Test
+  void usesAllFieldsInGeneratingString() {
+    Key key = new EntityV2TypeDocKey("AAA", "BBB", "CCC");
+
+    assertEquals("AAA:BBB:CCC", key.toString());
+  }
+}


### PR DESCRIPTION
## Description
Unlike V1 entities, V2 entities have IDs that are not controlled by entity service (to allow calculating without talking to ES), which means we can't guarantee their global uniqueness - that's up to the id implementation. This change updates the APIs to allow providing entity types in the byId-typed APIs, falling back to the existing behavior if they're not provided. If they _are_ provided *and* are a v2 entity type, a new key format is used that includes the entity type to keep the data from stomping on potential entities of a different type. Because no v2 entities are stored in EDS today, this change should be fully backwards compatible.


### Testing
Ran with this as part of a larger e2e change, added UTs here.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
