### PR TITLE
fix: support retrieving entity attributes for v2 typed ents

### DIFF
--- a/entity-service-impl/build.gradle.kts
+++ b/entity-service-impl/build.gradle.kts
@@ -9,6 +9,8 @@ dependencies {
   api("org.hypertrace.core.serviceframework:service-framework-spi:0.1.22")
   implementation("org.hypertrace.core.documentstore:document-store:0.5.4")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.4.0")
+  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.4.0")
+  implementation("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.10.4")
   implementation(project(":entity-type-service-rx-client"))
 
   implementation("com.google.protobuf:protobuf-java-util:3.15.6")

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityAttributeMapping.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityAttributeMapping.java
@@ -1,0 +1,69 @@
+package org.hypertrace.entity.query.service;
+
+import static java.util.stream.Collectors.toUnmodifiableMap;
+
+import com.typesafe.config.Config;
+import java.util.Map;
+import java.util.Optional;
+import org.hypertrace.core.attribute.service.cachingclient.CachingAttributeClient;
+import org.hypertrace.core.attribute.service.v1.AttributeMetadata;
+import org.hypertrace.core.attribute.service.v1.AttributeSource;
+import org.hypertrace.core.grpcutils.client.GrpcChannelRegistry;
+import org.hypertrace.core.grpcutils.context.RequestContext;
+
+class EntityAttributeMapping {
+  private static final String ATTRIBUTE_MAP_CONFIG_PATH = "entity.service.attributeMap";
+  private static final String ATTRIBUTE_SERVICE_HOST = "attribute.service.config.host";
+  private static final String ATTRIBUTE_SERVICE_PORT = "attribute.service.config.port";
+  static final String ENTITY_ATTRIBUTE_DOC_PREFIX = "attributes.";
+
+  private final CachingAttributeClient attributeClient;
+  private final Map<String, String> explicitDocStoreMappingsByAttributeId;
+
+  EntityAttributeMapping(Config config, GrpcChannelRegistry channelRegistry) {
+    this(
+        CachingAttributeClient.builder(
+                channelRegistry.forAddress(
+                    config.getString(ATTRIBUTE_SERVICE_HOST),
+                    config.getInt(ATTRIBUTE_SERVICE_PORT)))
+            .build(),
+        config.getConfigList(ATTRIBUTE_MAP_CONFIG_PATH).stream()
+            .collect(
+                toUnmodifiableMap(
+                    conf -> conf.getString("name"), conf -> conf.getString("subDocPath"))));
+  }
+
+  EntityAttributeMapping(
+      CachingAttributeClient attributeClient,
+      Map<String, String> explicitDocStoreMappingsByAttributeId) {
+    this.attributeClient = attributeClient;
+    this.explicitDocStoreMappingsByAttributeId = explicitDocStoreMappingsByAttributeId;
+  }
+
+  /**
+   * Returns the doc store path first looking at the hardcoded service config, then falling back to
+   * the attribute name defined in the config service.
+   *
+   * @return
+   */
+  public Optional<String> getDocStorePathByAttributeId(
+      RequestContext requestContext, String attributeId) {
+    return Optional.ofNullable(this.explicitDocStoreMappingsByAttributeId.get(attributeId))
+        .or(() -> this.calculateDocStorePathFromAttributeId(requestContext, attributeId));
+  }
+
+  private Optional<String> calculateDocStorePathFromAttributeId(
+      RequestContext requestContext, String attributeId) {
+    return requestContext.call(
+        () ->
+            this.attributeClient
+                .get(attributeId)
+                .filter(metadata -> metadata.getSourcesList().contains(AttributeSource.EDS))
+                .map(AttributeMetadata::getKey)
+                .map(key -> ENTITY_ATTRIBUTE_DOC_PREFIX + key)
+                .map(Optional::of)
+                .onErrorComplete()
+                .defaultIfEmpty(Optional.empty())
+                .blockingGet());
+  }
+}

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/EntityAttributeMappingTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/EntityAttributeMappingTest.java
@@ -1,0 +1,76 @@
+package org.hypertrace.entity.query.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.reactivex.rxjava3.core.Single;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import org.hypertrace.core.attribute.service.cachingclient.CachingAttributeClient;
+import org.hypertrace.core.attribute.service.v1.AttributeMetadata;
+import org.hypertrace.core.attribute.service.v1.AttributeSource;
+import org.hypertrace.core.grpcutils.context.RequestContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EntityAttributeMappingTest {
+
+  @Mock CachingAttributeClient mockAttributeClient;
+  @Mock RequestContext mockRequestContext;
+
+  @Test
+  void returnsMappingFromConfig() {
+    EntityAttributeMapping attributeMapping =
+        new EntityAttributeMapping(
+            this.mockAttributeClient, Map.of("some-id", "attributes.some-key"));
+
+    assertEquals(
+        Optional.of("attributes.some-key"),
+        attributeMapping.getDocStorePathByAttributeId(mockRequestContext, "some-id"));
+
+    // Should have priority over attribute client
+    verifyNoInteractions(mockAttributeClient);
+  }
+
+  @Test
+  void returnsMappingFromAttributeService() {
+    when(mockRequestContext.call(any())).thenCallRealMethod();
+    EntityAttributeMapping attributeMapping =
+        new EntityAttributeMapping(this.mockAttributeClient, Collections.emptyMap());
+    AttributeMetadata sourcelessMetadata =
+        AttributeMetadata.newBuilder().setKey("some-key").build();
+    when(this.mockAttributeClient.get("some-id")).thenReturn(Single.just(sourcelessMetadata));
+
+    // Empty result, since the mock metadata doesn't have an entity source
+    assertEquals(
+        Optional.empty(),
+        attributeMapping.getDocStorePathByAttributeId(mockRequestContext, "some-id"));
+
+    AttributeMetadata goodMetadata =
+        sourcelessMetadata.toBuilder().addSources(AttributeSource.EDS).build();
+    when(this.mockAttributeClient.get("some-id")).thenReturn(Single.just(goodMetadata));
+
+    assertEquals(
+        Optional.of("attributes.some-key"),
+        attributeMapping.getDocStorePathByAttributeId(mockRequestContext, "some-id"));
+  }
+
+  @Test
+  void returnsEmptyIfNoMapping() {
+    when(mockRequestContext.call(any())).thenCallRealMethod();
+    EntityAttributeMapping attributeMapping =
+        new EntityAttributeMapping(this.mockAttributeClient, Collections.emptyMap());
+    when(this.mockAttributeClient.get("some-id")).thenReturn(Single.error(new RuntimeException()));
+
+    // Empty result, since attribute client threw error
+    assertEquals(
+        Optional.empty(),
+        attributeMapping.getDocStorePathByAttributeId(mockRequestContext, "some-id"));
+  }
+}

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/EntityQueryConverterTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/EntityQueryConverterTest.java
@@ -2,12 +2,12 @@ package org.hypertrace.entity.query.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
 import java.time.Instant;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.Optional;
+import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.entity.data.service.v1.Query;
 import org.hypertrace.entity.query.service.v1.ColumnIdentifier;
 import org.hypertrace.entity.query.service.v1.EntityQueryRequest;
@@ -23,46 +23,55 @@ import org.hypertrace.entity.v1.entitytype.EntityType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 public class EntityQueryConverterTest {
-  private static final String EQS_COLUMN_NAME1 = "eqsColumn1";
+  private static final String ATTRIBUTE_ID_NAME1 = "eqsColumn1";
   private static final String EDS_COLUMN_NAME1 = "edsColumn1";
-  private static final String EQS_COLUMN_NAME2 = "eqsColumn2";
+  private static final String ATTRIBUTE_ID_NAME2 = "eqsColumn2";
   private static final String EDS_COLUMN_NAME2 = "edsColumn2";
 
-  private final Map<String, String> attributeMap = new HashMap<>();
+  @Mock
+  EntityAttributeMapping mockAttributeMapping;
+  @Mock
+  RequestContext mockRequestContext;
+  private EntityQueryConverter queryConverter;
 
   @BeforeEach
   public void setup() {
-    attributeMap.put(EQS_COLUMN_NAME1, EDS_COLUMN_NAME1);
-    attributeMap.put(EQS_COLUMN_NAME2, EDS_COLUMN_NAME2);
+    this.queryConverter = new EntityQueryConverter(mockAttributeMapping);
   }
 
   @Test
   public void test_convertToEDSQuery_limitAndOffset() {
     // no offset and limit specified
     EntityQueryRequest request = EntityQueryRequest.newBuilder().build();
-    Query convertedQuery = EntityQueryConverter.convertToEDSQuery(request, Collections.emptyMap());
+    Query convertedQuery = this.queryConverter.convertToEDSQuery(mockRequestContext, request);
     assertEquals(0, convertedQuery.getOffset());
     assertEquals(0, convertedQuery.getLimit());
 
     int limit = 3;
     int offset = 1;
     request = EntityQueryRequest.newBuilder().setLimit(limit).setOffset(offset).build();
-    convertedQuery = EntityQueryConverter.convertToEDSQuery(request, Collections.emptyMap());
+    convertedQuery = this.queryConverter.convertToEDSQuery(mockRequestContext, request);
     assertEquals(limit, convertedQuery.getLimit());
     assertEquals(offset, convertedQuery.getOffset());
   }
 
   @Test
   public void test_convertToEdsQuery_orderByExpression() {
+    mockAttribute1();
+    mockAttribute2();
     EntityQueryRequest request = EntityQueryRequest.newBuilder()
         .addOrderBy(
             OrderByExpression.newBuilder()
                 .setExpression(
                     Expression.newBuilder().setColumnIdentifier(
                         ColumnIdentifier.newBuilder()
-                          .setColumnName(EQS_COLUMN_NAME1)
+                          .setColumnName(ATTRIBUTE_ID_NAME1)
                           .build()))
                 .setOrder(SortOrder.ASC)
             .build())
@@ -71,12 +80,12 @@ public class EntityQueryConverterTest {
                 .setExpression(
                     Expression.newBuilder().setColumnIdentifier(
                         ColumnIdentifier.newBuilder()
-                            .setColumnName(EQS_COLUMN_NAME2)
+                            .setColumnName(ATTRIBUTE_ID_NAME2)
                             .build()))
                 .setOrder(SortOrder.DESC)
                 .build())
         .build();
-    Query convertedQuery = EntityQueryConverter.convertToEDSQuery(request, attributeMap);
+    Query convertedQuery = queryConverter.convertToEDSQuery(mockRequestContext, request);
     assertEquals(2, convertedQuery.getOrderByCount());
     // ensure that the order of OrderByExpression is maintained
     assertEquals(EDS_COLUMN_NAME1, convertedQuery.getOrderByList().get(0).getName());
@@ -90,16 +99,17 @@ public class EntityQueryConverterTest {
 
   @Test
   public void test_convertToEdsQuery_missingSortOrderByExpression_assignWithAscByDefault() {
+    mockAttribute1();
     EntityQueryRequest request = EntityQueryRequest.newBuilder()
         .addOrderBy(
             OrderByExpression.newBuilder()
                 .setExpression(
                     Expression.newBuilder().setColumnIdentifier(
                         ColumnIdentifier.newBuilder()
-                            .setColumnName(EQS_COLUMN_NAME1)
+                            .setColumnName(ATTRIBUTE_ID_NAME1)
                             .build()))
         ).build();
-    Query convertedQuery = EntityQueryConverter.convertToEDSQuery(request, attributeMap);
+    Query convertedQuery = queryConverter.convertToEDSQuery(mockRequestContext, request);
     assertEquals(1, convertedQuery.getOrderByCount());
     // ensure that the order of OrderByExpression is maintained
     assertEquals(EDS_COLUMN_NAME1, convertedQuery.getOrderByList().get(0).getName());
@@ -109,12 +119,13 @@ public class EntityQueryConverterTest {
 
   @Test
   public void test_filter() {
+    mockAttribute2();
     EntityQueryRequest queryRequest = EntityQueryRequest.newBuilder()
         .setEntityType(EntityType.SERVICE.name())
         .setFilter(
             Filter.newBuilder()
                 .setOperatorValue(Operator.LT.getNumber())
-                .setLhs(Expression.newBuilder().setColumnIdentifier(ColumnIdentifier.newBuilder().setColumnName("SERVICE.createdTime").build()).build())
+                .setLhs(Expression.newBuilder().setColumnIdentifier(ColumnIdentifier.newBuilder().setColumnName(ATTRIBUTE_ID_NAME2).build()).build())
                 .setRhs(Expression.newBuilder().setLiteral(
                     LiteralConstant.newBuilder().setValue(
                         org.hypertrace.entity.query.service.v1.Value.newBuilder()
@@ -125,7 +136,7 @@ public class EntityQueryConverterTest {
                     build())
                 .build())
         .build();
-    Query query = EntityQueryConverter.convertToEDSQuery(queryRequest, Map.of("SERVICE.createdTime", "createdTime"));
+    Query query = queryConverter.convertToEDSQuery(mockRequestContext, queryRequest);
     Assertions.assertEquals(EntityType.SERVICE.name(), query.getEntityType());
     Assertions.assertNotNull(query.getFilter());
   }
@@ -142,25 +153,37 @@ public class EntityQueryConverterTest {
                 .setOrder(SortOrder.ASC).build()
         ).build();
     assertThrows(UnsupportedOperationException.class,
-        () -> EntityQueryConverter.convertToEDSQuery(request, Collections.emptyMap()));
+        () -> queryConverter.convertToEDSQuery(mockRequestContext, request));
   }
 
   @Test
   public void test_convertEqsSelections_DocStoreSelections() {
+    mockAttribute1();
+    mockAttribute2();
     List<Expression> expressions =
         List.of(
             Expression.newBuilder()
                 .setColumnIdentifier(
-                    ColumnIdentifier.newBuilder().setColumnName(EQS_COLUMN_NAME1).build())
+                    ColumnIdentifier.newBuilder().setColumnName(ATTRIBUTE_ID_NAME1).build())
                 .build(),
             Expression.newBuilder()
                 .setColumnIdentifier(
-                    ColumnIdentifier.newBuilder().setColumnName(EQS_COLUMN_NAME2).build())
+                    ColumnIdentifier.newBuilder().setColumnName(ATTRIBUTE_ID_NAME2).build())
                 .build());
     List<String> docStoreSelections =
-        EntityQueryConverter.convertSelectionsToDocStoreSelections(expressions, attributeMap);
+        queryConverter.convertSelectionsToDocStoreSelections(mockRequestContext, expressions);
     assertEquals(2, docStoreSelections.size());
     assertEquals(EDS_COLUMN_NAME1, docStoreSelections.get(0));
     assertEquals(EDS_COLUMN_NAME2, docStoreSelections.get(1));
+  }
+
+  private void mockAttribute1() {
+    when(mockAttributeMapping.getDocStorePathByAttributeId(mockRequestContext, ATTRIBUTE_ID_NAME1))
+        .thenReturn(Optional.of(EDS_COLUMN_NAME1));
+  }
+
+  private void mockAttribute2() {
+    when(mockAttributeMapping.getDocStorePathByAttributeId(mockRequestContext, ATTRIBUTE_ID_NAME2))
+        .thenReturn(Optional.of(EDS_COLUMN_NAME2));
   }
 }

--- a/entity-service/src/main/resources/configs/common/application.conf
+++ b/entity-service/src/main/resources/configs/common/application.conf
@@ -12,6 +12,13 @@ entity.service.config = {
     }
   }
 }
+attribute.service.config = {
+  host = localhost
+  host = ${?ATTRIBUTE_SERVICE_HOST_CONFIG}
+  port = 9012
+  port = ${?ATTRIBUTE_SERVICE_PORT_CONFIG}
+}
+
 entity.service.attributeMap = [
   {
     "scope": "API",

--- a/helm/templates/entity-service-config.yaml
+++ b/helm/templates/entity-service-config.yaml
@@ -19,6 +19,10 @@ data:
         }
       }
     }
+    attribute.service.config = {
+      host = {{ .Values.entityServiceConfig.attributeService.host }}
+      port = {{ .Values.entityServiceConfig.attributeService.port }}
+    }
   {{- if .Values.attributes }}
     entity.service.attributeMap = [
   {{- range $i, $v := .Values.attributes }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -87,6 +87,9 @@ entityServiceConfig:
     host: postgres
     port: 5432
     url: ""
+  attributeService:
+    host: attribute-service
+    port: 9012
 
 attributes: []
 extraAttributes: []


### PR DESCRIPTION
## Description
This change is the flipside of https://github.com/hypertrace/entity-service/pull/92 - it adds support for retrieving v2 typed entities via EQS. Previously, we had two different schemas for an entity - one defined in attribute service, and a corresponding one mapping it into entity service. With v2 schemas, entities are only defined via attributes - the entity definition simply specifies important attributes such as the name and identifier. Full backwards compatibility

### Testing
Tested E2E, added + updated UTs

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

