### PR TITLE
feat: add merge upsert api with condition support

### DIFF
--- a/entity-service-api/src/main/proto/org/hypertrace/entity/data/service/v1/entity_data_request.proto
+++ b/entity-service-api/src/main/proto/org/hypertrace/entity/data/service/v1/entity_data_request.proto
@@ -70,3 +70,32 @@ enum SortOrder {
   ASC = 0;
   DESC = 1;
 }
+
+message MergeAndUpsertEntityRequest {
+  Entity entity = 1;
+  UpsertCondition upsertCondition = 2;
+
+  message UpsertCondition {
+    oneof update_condition {
+      Predicate property_predicate = 2;
+    }
+
+    message Predicate {
+      string attribute_key = 1;
+      PredicateOperator operator = 2;
+      AttributeValue value = 3;
+
+      enum PredicateOperator {
+        PREDICATE_OPERATOR_UNSPECIFIED = 0;
+        PREDICATE_OPERATOR_EQUALS = 1;
+        PREDICATE_OPERATOR_NOT_EQUALS = 2;
+        PREDICATE_OPERATOR_GREATER_THAN = 3;
+        PREDICATE_OPERATOR_LESS_THAN = 4;
+      }
+    }
+  }
+}
+
+message MergeAndUpsertEntityResponse {
+  Entity entity = 1;
+}

--- a/entity-service-api/src/main/proto/org/hypertrace/entity/data/service/v1/entity_data_service.proto
+++ b/entity-service-api/src/main/proto/org/hypertrace/entity/data/service/v1/entity_data_service.proto
@@ -10,6 +10,8 @@ import "org/hypertrace/entity/data/service/v1/entity_data_request.proto";
 service EntityDataService {
   rpc upsert (Entity) returns (Entity) {
   }
+  rpc MergeAndUpsertEntity(MergeAndUpsertEntityRequest) returns (MergeAndUpsertEntityResponse){}
+
   rpc upsertEntities (Entities) returns (Empty) {
   }
   rpc getAndUpsertEntities (Entities) returns (stream Entity) {

--- a/entity-service-api/src/main/proto/org/hypertrace/entity/type/service/v2/entity_type_service.proto
+++ b/entity-service-api/src/main/proto/org/hypertrace/entity/type/service/v2/entity_type_service.proto
@@ -8,6 +8,7 @@ message EntityType {
   string attribute_scope = 2;
   string id_attribute_key = 3;
   string name_attribute_key = 4;
+  string timestamp_attribute_key = 5;
 }
 
 message UpsertEntityTypeRequest {

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/data/service/UpsertConditionMatcher.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/data/service/UpsertConditionMatcher.java
@@ -1,0 +1,101 @@
+package org.hypertrace.entity.data.service;
+
+import java.util.Comparator;
+import java.util.function.BiPredicate;
+import org.hypertrace.entity.data.service.v1.AttributeValue;
+import org.hypertrace.entity.data.service.v1.Entity;
+import org.hypertrace.entity.data.service.v1.MergeAndUpsertEntityRequest.UpsertCondition;
+import org.hypertrace.entity.data.service.v1.MergeAndUpsertEntityRequest.UpsertCondition.Predicate;
+import org.hypertrace.entity.data.service.v1.MergeAndUpsertEntityRequest.UpsertCondition.Predicate.PredicateOperator;
+import org.hypertrace.entity.data.service.v1.Value;
+
+class UpsertConditionMatcher {
+  private static final Comparator<AttributeValue> ATTRIBUTE_VALUE_COMPARATOR =
+      new AttributeValueComparator();
+
+  boolean matches(Entity existingEntity, UpsertCondition upsertCondition) {
+    return !upsertCondition.hasPropertyPredicate()
+        || this.matchesPredicate(existingEntity, upsertCondition.getPropertyPredicate());
+  }
+
+  private boolean matchesPredicate(Entity entity, Predicate predicate) {
+    return this.asBipredicate(predicate.getOperator())
+        .test(
+            entity
+                .getAttributesMap()
+                .getOrDefault(predicate.getAttributeKey(), AttributeValue.getDefaultInstance()),
+            predicate.getValue());
+  }
+
+  private BiPredicate<AttributeValue, AttributeValue> asBipredicate(PredicateOperator operator) {
+    switch (operator) {
+      case PREDICATE_OPERATOR_EQUALS:
+        return AttributeValue::equals;
+      case PREDICATE_OPERATOR_NOT_EQUALS:
+        return (first, second) -> !first.equals(second);
+      case PREDICATE_OPERATOR_GREATER_THAN:
+        return (first, second) -> ATTRIBUTE_VALUE_COMPARATOR.compare(first, second) > 0;
+      case PREDICATE_OPERATOR_LESS_THAN:
+        return (first, second) -> ATTRIBUTE_VALUE_COMPARATOR.compare(first, second) < 0;
+      case PREDICATE_OPERATOR_UNSPECIFIED:
+      case UNRECOGNIZED:
+      default:
+        throw new IllegalArgumentException("Unrecognized operator: " + operator);
+    }
+  }
+
+  private static final class AttributeValueComparator implements Comparator<AttributeValue> {
+    @Override
+    public int compare(AttributeValue o1, AttributeValue o2) {
+      if (o1.getValue().getTypeCase() != o2.getValue().getTypeCase()) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Mismatched values %s and %s",
+                o1.getValue().getTypeCase(), o2.getValue().getTypeCase()));
+      }
+
+      Comparable<Object> first = this.getComparableValue(o1);
+      Comparable<Object> second = this.getComparableValue(o2);
+      return first.compareTo(second);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Comparable<Object> getComparableValue(AttributeValue attributeValue) {
+      switch (attributeValue.getTypeCase()) {
+        case VALUE:
+          return (Comparable<Object>) this.getComparableValue(attributeValue.getValue());
+        case VALUE_LIST:
+        case VALUE_MAP:
+        case TYPE_NOT_SET:
+        default:
+          throw new IllegalArgumentException(
+              "Unsupported value type: " + attributeValue.getTypeCase());
+      }
+    }
+
+    private Comparable<?> getComparableValue(Value value) {
+      switch (value.getTypeCase()) {
+        case INT:
+          return value.getInt();
+        case STRING:
+          return value.getString();
+        case BOOLEAN:
+          return value.getBoolean();
+        case LONG:
+          return value.getLong();
+        case FLOAT:
+          return value.getFloat();
+        case DOUBLE:
+          return value.getDouble();
+        case BYTES:
+          return value.getBytes().asReadOnlyByteBuffer();
+        case TIMESTAMP:
+          return value.getTimestamp();
+        case CUSTOM:
+        case TYPE_NOT_SET:
+        default:
+          throw new IllegalArgumentException("Unexpected value: " + value.getTypeCase());
+      }
+    }
+  }
+}

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/data/service/UpsertConditionMatcherTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/data/service/UpsertConditionMatcherTest.java
@@ -1,0 +1,253 @@
+package org.hypertrace.entity.data.service;
+
+import static org.hypertrace.entity.data.service.v1.MergeAndUpsertEntityRequest.UpsertCondition.Predicate.PredicateOperator.PREDICATE_OPERATOR_EQUALS;
+import static org.hypertrace.entity.data.service.v1.MergeAndUpsertEntityRequest.UpsertCondition.Predicate.PredicateOperator.PREDICATE_OPERATOR_GREATER_THAN;
+import static org.hypertrace.entity.data.service.v1.MergeAndUpsertEntityRequest.UpsertCondition.Predicate.PredicateOperator.PREDICATE_OPERATOR_LESS_THAN;
+import static org.hypertrace.entity.data.service.v1.MergeAndUpsertEntityRequest.UpsertCondition.Predicate.PredicateOperator.PREDICATE_OPERATOR_NOT_EQUALS;
+import static org.hypertrace.entity.data.service.v1.MergeAndUpsertEntityRequest.UpsertCondition.Predicate.PredicateOperator.PREDICATE_OPERATOR_UNSPECIFIED;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.protobuf.ByteString;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import org.hypertrace.entity.data.service.v1.AttributeValue;
+import org.hypertrace.entity.data.service.v1.AttributeValueList;
+import org.hypertrace.entity.data.service.v1.AttributeValueMap;
+import org.hypertrace.entity.data.service.v1.Entity;
+import org.hypertrace.entity.data.service.v1.MergeAndUpsertEntityRequest.UpsertCondition;
+import org.hypertrace.entity.data.service.v1.MergeAndUpsertEntityRequest.UpsertCondition.Predicate;
+import org.hypertrace.entity.data.service.v1.MergeAndUpsertEntityRequest.UpsertCondition.Predicate.PredicateOperator;
+import org.hypertrace.entity.data.service.v1.Value;
+import org.junit.jupiter.api.Test;
+
+class UpsertConditionMatcherTest {
+
+  private final UpsertConditionMatcher matcher = new UpsertConditionMatcher();
+
+  @Test
+  void matchesEquality() {
+    verifyOperatorBehavior(string("foo"), string("foo"), string("bar"), PREDICATE_OPERATOR_EQUALS);
+    verifyOperatorBehavior(
+        stringList("foo1", "foo2"),
+        stringList("foo1", "foo2"),
+        stringList("foo1", "bar2"),
+        PREDICATE_OPERATOR_EQUALS);
+    verifyOperatorBehavior(
+        stringMap(Map.of("k1", "v1", "k2", "v2")),
+        stringMap(Map.of("k1", "v1", "k2", "v2")),
+        stringMap(Map.of("k1", "v1", "k2", "v2_other")),
+        PREDICATE_OPERATOR_EQUALS);
+    verifyOperatorBehavior(
+        integerValue(1), integerValue(1), integerValue(2), PREDICATE_OPERATOR_EQUALS);
+    verifyOperatorBehavior(longValue(1), longValue(1), longValue(2), PREDICATE_OPERATOR_EQUALS);
+    verifyOperatorBehavior(timestamp(1), timestamp(1), timestamp(2), PREDICATE_OPERATOR_EQUALS);
+    verifyOperatorBehavior(
+        byteValue("foo"), byteValue("foo"), byteValue("bar"), PREDICATE_OPERATOR_EQUALS);
+    verifyOperatorBehavior(
+        floatValue(3.14f), floatValue(3.14f), floatValue(3.5f), PREDICATE_OPERATOR_EQUALS);
+    verifyOperatorBehavior(
+        doubleValue(3.14), doubleValue(3.14), doubleValue(3.5), PREDICATE_OPERATOR_EQUALS);
+    verifyOperatorBehavior(
+        booleanValue(true), booleanValue(true), booleanValue(false), PREDICATE_OPERATOR_EQUALS);
+  }
+
+  @Test
+  void matchesInequality() {
+    verifyOperatorBehavior(
+        string("foo"), string("bar"), string("foo"), PREDICATE_OPERATOR_NOT_EQUALS);
+    verifyOperatorBehavior(
+        stringList("foo1", "foo2"),
+        stringList("foo1", "bar2"),
+        stringList("foo1", "foo2"),
+        PREDICATE_OPERATOR_NOT_EQUALS);
+    verifyOperatorBehavior(
+        stringMap(Map.of("k1", "v1", "k2", "v2")),
+        stringMap(Map.of("k1", "v1", "k2", "v2_other")),
+        stringMap(Map.of("k1", "v1", "k2", "v2")),
+        PREDICATE_OPERATOR_NOT_EQUALS);
+    verifyOperatorBehavior(
+        integerValue(2), integerValue(1), integerValue(2), PREDICATE_OPERATOR_NOT_EQUALS);
+    verifyOperatorBehavior(longValue(2), longValue(1), longValue(2), PREDICATE_OPERATOR_NOT_EQUALS);
+    verifyOperatorBehavior(timestamp(2), timestamp(1), timestamp(2), PREDICATE_OPERATOR_NOT_EQUALS);
+    verifyOperatorBehavior(
+        byteValue("bar"), byteValue("foo"), byteValue("bar"), PREDICATE_OPERATOR_NOT_EQUALS);
+    verifyOperatorBehavior(
+        floatValue(3.5f), floatValue(3.14f), floatValue(3.5f), PREDICATE_OPERATOR_NOT_EQUALS);
+    verifyOperatorBehavior(
+        doubleValue(3.5f), doubleValue(3.14), doubleValue(3.5), PREDICATE_OPERATOR_NOT_EQUALS);
+    verifyOperatorBehavior(
+        booleanValue(false),
+        booleanValue(true),
+        booleanValue(false),
+        PREDICATE_OPERATOR_NOT_EQUALS);
+  }
+
+  @Test
+  void matchesLessThan() {
+    verifyOperatorBehavior(
+        integerValue(2), integerValue(3), integerValue(1), PREDICATE_OPERATOR_LESS_THAN);
+    verifyOperatorBehavior(longValue(2), longValue(3), longValue(1), PREDICATE_OPERATOR_LESS_THAN);
+    verifyOperatorBehavior(timestamp(2), timestamp(3), timestamp(1), PREDICATE_OPERATOR_LESS_THAN);
+    verifyOperatorBehavior(
+        floatValue(3.5f), floatValue(3.64f), floatValue(3.14f), PREDICATE_OPERATOR_LESS_THAN);
+    verifyOperatorBehavior(
+        doubleValue(3.5f), doubleValue(3.64), doubleValue(3.14), PREDICATE_OPERATOR_LESS_THAN);
+  }
+
+  @Test
+  void matchesGreaterThan() {
+    verifyOperatorBehavior(
+        integerValue(2), integerValue(1), integerValue(3), PREDICATE_OPERATOR_GREATER_THAN);
+    verifyOperatorBehavior(
+        longValue(2), longValue(1), longValue(3), PREDICATE_OPERATOR_GREATER_THAN);
+    verifyOperatorBehavior(
+        timestamp(2), timestamp(1), timestamp(3), PREDICATE_OPERATOR_GREATER_THAN);
+    verifyOperatorBehavior(
+        floatValue(3.5f), floatValue(3.14f), floatValue(3.64f), PREDICATE_OPERATOR_GREATER_THAN);
+    verifyOperatorBehavior(
+        doubleValue(3.5f), doubleValue(3.14), doubleValue(3.64), PREDICATE_OPERATOR_GREATER_THAN);
+  }
+
+  @Test
+  void returnsTrueIfNoCondition() {
+    assertTrue(matcher.matches(Entity.getDefaultInstance(), UpsertCondition.getDefaultInstance()));
+  }
+
+  @Test
+  void handlesMissingValues() {
+    Entity entity = entity(Map.of());
+    assertFalse(
+        matcher.matches(entity, condition("key1", PREDICATE_OPERATOR_EQUALS, string("foo"))));
+    assertTrue(
+        matcher.matches(entity, condition("key1", PREDICATE_OPERATOR_NOT_EQUALS, string("foo"))));
+
+    // Throws for comparisons
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            matcher.matches(
+                entity, condition("key1", PREDICATE_OPERATOR_LESS_THAN, integerValue(10))));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            matcher.matches(
+                entity, condition("key1", PREDICATE_OPERATOR_GREATER_THAN, integerValue(10))));
+  }
+
+  @Test
+  void handlesValuesDifferentTypes() {
+    Entity entity = entity(Map.of("key1", string("foo")));
+    assertFalse(
+        matcher.matches(entity, condition("key1", PREDICATE_OPERATOR_EQUALS, integerValue(5))));
+    assertTrue(
+        matcher.matches(entity, condition("key1", PREDICATE_OPERATOR_NOT_EQUALS, integerValue(5))));
+
+    // Throws for comparisons
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            matcher.matches(
+                entity, condition("key1", PREDICATE_OPERATOR_LESS_THAN, integerValue(5))));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            matcher.matches(
+                entity, condition("key1", PREDICATE_OPERATOR_GREATER_THAN, integerValue(5))));
+  }
+
+  @Test
+  void throwsIfUnknownOperator() {
+    Entity entity = entity(Map.of("key1", string("foo")));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            matcher.matches(
+                entity, condition("key1", PREDICATE_OPERATOR_UNSPECIFIED, string("foo"))));
+  }
+
+  private void verifyOperatorBehavior(
+      AttributeValue entityValue,
+      AttributeValue rhsGoodValue,
+      AttributeValue rhsBadValue,
+      PredicateOperator operator) {
+    Entity entity = entity(Map.of("key1", entityValue));
+    assertTrue(matcher.matches(entity, condition("key1", operator, rhsGoodValue)));
+    assertFalse(matcher.matches(entity, condition("key1", operator, rhsBadValue)));
+  }
+
+  private AttributeValue string(String value) {
+    return AttributeValue.newBuilder().setValue(Value.newBuilder().setString(value)).build();
+  }
+
+  private AttributeValue integerValue(int value) {
+    return AttributeValue.newBuilder().setValue(Value.newBuilder().setInt(value)).build();
+  }
+
+  private AttributeValue booleanValue(boolean value) {
+    return AttributeValue.newBuilder().setValue(Value.newBuilder().setBoolean(value)).build();
+  }
+
+  private AttributeValue longValue(long value) {
+    return AttributeValue.newBuilder().setValue(Value.newBuilder().setLong(value)).build();
+  }
+
+  private AttributeValue floatValue(float value) {
+    return AttributeValue.newBuilder().setValue(Value.newBuilder().setFloat(value)).build();
+  }
+
+  private AttributeValue doubleValue(double value) {
+    return AttributeValue.newBuilder().setValue(Value.newBuilder().setDouble(value)).build();
+  }
+
+  private AttributeValue byteValue(String value) {
+    return AttributeValue.newBuilder()
+        .setValue(Value.newBuilder().setBytes(ByteString.copyFromUtf8(value)))
+        .build();
+  }
+
+  private AttributeValue timestamp(long value) {
+    return AttributeValue.newBuilder().setValue(Value.newBuilder().setTimestamp(value)).build();
+  }
+
+  private AttributeValue stringList(String... values) {
+    return Arrays.stream(values)
+        .map(this::string)
+        .collect(
+            Collectors.collectingAndThen(
+                Collectors.toList(),
+                list ->
+                    AttributeValue.newBuilder()
+                        .setValueList(AttributeValueList.newBuilder().addAllValues(list))
+                        .build()));
+  }
+
+  private AttributeValue stringMap(Map<String, String> map) {
+    return map.entrySet().stream()
+        .collect(
+            Collectors.collectingAndThen(
+                Collectors.toUnmodifiableMap(Entry::getKey, entry -> string(entry.getValue())),
+                attributeValueMap ->
+                    AttributeValue.newBuilder()
+                        .setValueMap(AttributeValueMap.newBuilder().putAllValues(attributeValueMap))
+                        .build()));
+  }
+
+  private Entity entity(Map<String, AttributeValue> attributeValueMap) {
+    return Entity.newBuilder().putAllAttributes(attributeValueMap).build();
+  }
+
+  private UpsertCondition condition(String key, PredicateOperator operator, AttributeValue value) {
+    return UpsertCondition.newBuilder()
+        .setPropertyPredicate(
+            Predicate.newBuilder()
+                .setAttributeKey(key)
+                .setOperator(operator)
+                .setValue(value)
+                .build())
+        .build();
+  }
+}

--- a/entity-service/build.gradle.kts
+++ b/entity-service/build.gradle.kts
@@ -79,6 +79,7 @@ dependencies {
   implementation("com.typesafe:config:1.4.1")
 
   integrationTestImplementation(project(":entity-service-client"))
+  integrationTestImplementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.4.0")
   integrationTestImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   integrationTestImplementation("org.hypertrace.core.serviceframework:integrationtest-service-framework:0.1.22")
 }


### PR DESCRIPTION
## Description
This change adds a new upsert API that has two main distinctions from the existing API:
1. Instead of overwriting an existing entity, it will merge with it
2. It supports a predicate that will be evaluated against any existing entity, to check before proceeding.

Both changes help support easier high write volume use cases - for example, multiple enrichers running in parallel. The merge case saves us from having to do two sequential round trips (to prevent overwriting data) in the update case, and the predicate helps us to better enforce write consistency - that is, ensuring a newer update doesn't arrive earlier than an older. Note this is not a full consistency guarantee, but likely good enough for our purposes.

### Testing
Ran E2E, also added ITs and UTs.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
