### PR TITLE
feat: add async entity write to rx client

### DIFF
--- a/entity-data-service-rx-client/src/main/java/org/hypertrace/entity/data/service/rxclient/EntityDataCachingClient.java
+++ b/entity-data-service-rx-client/src/main/java/org/hypertrace/entity/data/service/rxclient/EntityDataCachingClient.java
@@ -1,44 +1,150 @@
 package org.hypertrace.entity.data.service.rxclient;
 
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import io.grpc.CallCredentials;
 import io.grpc.Channel;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.core.SingleObserver;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.subjects.SingleSubject;
+import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import org.hypertrace.entity.data.service.v1.Entity;
 import org.hypertrace.entity.data.service.v1.EntityDataServiceGrpc;
 import org.hypertrace.entity.data.service.v1.EntityDataServiceGrpc.EntityDataServiceStub;
+import org.hypertrace.entity.data.service.v1.MergeAndUpsertEntityRequest;
+import org.hypertrace.entity.data.service.v1.MergeAndUpsertEntityRequest.UpsertCondition;
+import org.hypertrace.entity.data.service.v1.MergeAndUpsertEntityResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class EntityDataCachingClient implements EntityDataClient {
+  private static final Logger LOG = LoggerFactory.getLogger(EntityDataCachingClient.class);
   private final EntityDataServiceStub entityDataClient;
-  private final LoadingCache<EntityCacheKey, Single<Entity>> cache;
+  private final LoadingCache<EntityKey, Single<Entity>> cache;
+  private final ConcurrentMap<EntityKey, PendingEntityUpdate> pendingEntityUpdates =
+      new ConcurrentHashMap<>();
+  private final Clock clock;
 
   EntityDataCachingClient(
+      Clock clock,
       @Nonnull Channel channel,
       @Nonnull CallCredentials credentials,
       int maxCacheContexts,
       @Nonnull Duration cacheExpiration) {
+    this.clock = clock;
     this.entityDataClient = EntityDataServiceGrpc.newStub(channel).withCallCredentials(credentials);
     this.cache =
         CacheBuilder.newBuilder()
             .maximumSize(maxCacheContexts)
             .expireAfterWrite(cacheExpiration)
-            .build(CacheLoader.from(this::upsertEntity));
+            .build(CacheLoader.from(this::upsertEntityWithoutCaching));
   }
 
   @Override
   public Single<Entity> getOrCreateEntity(Entity entity) {
-    EntityCacheKey cacheKey = EntityCacheKey.entityInCurrentContext(entity);
-    return this.cache.getUnchecked(cacheKey).doOnError(x -> this.cache.invalidate(cacheKey));
+    EntityKey entityKey = EntityKey.entityInCurrentContext(entity);
+    return this.cache.getUnchecked(entityKey).doOnError(x -> this.cache.invalidate(entityKey));
   }
 
-  private Single<Entity> upsertEntity(EntityCacheKey key) {
-    return key.getExecutionContext().<Entity>stream(
-            streamObserver -> this.entityDataClient.upsert(key.getInputEntity(), streamObserver))
+  @Override
+  public Single<Entity> createOrUpdateEntityEventually(
+      Entity entity, UpsertCondition condition, Duration maximumUpsertDelay) {
+    SingleSubject<Entity> singleSubject = SingleSubject.create();
+    EntityKey entityKey = EntityKey.entityInCurrentContext(entity);
+    if (this.pendingEntityUpdates.containsKey(entityKey)) {
+      // Update the key - not strictly necessary (because the pending update holds the write data),
+      // but good hygiene
+      this.pendingEntityUpdates.put(entityKey, this.pendingEntityUpdates.get(entityKey));
+    }
+    this.pendingEntityUpdates
+        .computeIfAbsent(entityKey, unused -> new PendingEntityUpdate())
+        .addNewUpdate(entityKey, singleSubject, condition, maximumUpsertDelay);
+    return singleSubject;
+  }
+
+  @Override
+  public Single<Entity> createOrUpdateEntity(Entity entity, UpsertCondition upsertCondition) {
+    return this.createOrUpdateEntity(EntityKey.entityInCurrentContext(entity), upsertCondition);
+  }
+
+  private Single<Entity> createOrUpdateEntity(EntityKey entityKey, UpsertCondition upsertCondition) {
+    Single<Entity> updateResult =
+        this.upsertEntityWithoutCaching(entityKey, upsertCondition).cache();
+    EntityDataCachingClient.this.cache.put(entityKey, updateResult);
+    return updateResult;
+  }
+
+  private Single<Entity> upsertEntityWithoutCaching(EntityKey key) {
+    return this.upsertEntityWithoutCaching(key, UpsertCondition.getDefaultInstance());
+  }
+
+  private Single<Entity> upsertEntityWithoutCaching(EntityKey key, UpsertCondition condition) {
+    return key.getExecutionContext().<MergeAndUpsertEntityResponse>stream(
+            streamObserver ->
+                this.entityDataClient.mergeAndUpsertEntity(
+                    MergeAndUpsertEntityRequest.newBuilder()
+                        .setEntity(key.getInputEntity())
+                        .setUpsertCondition(condition)
+                        .build(),
+                    streamObserver))
+        .map(MergeAndUpsertEntityResponse::getEntity)
         .singleOrError()
         .cache();
+  }
+
+  private class PendingEntityUpdate {
+    private final List<SingleObserver<Entity>> responseObservers = new LinkedList<>();
+    private EntityKey entityKey;
+    private Disposable updateExecutionTimer;
+    private Instant currentDeadline;
+    private UpsertCondition condition;
+
+    private void executeUpdate() {
+      LOG.warn(
+          "Executing update for {} at {}", entityKey.getInputEntity().getEntityId(), Instant.now());
+
+      EntityDataCachingClient.this.pendingEntityUpdates.remove(entityKey);
+
+      Single<Entity> updateResult =
+          EntityDataCachingClient.this.createOrUpdateEntity(entityKey, condition).cache();
+      EntityDataCachingClient.this.cache.put(entityKey, updateResult);
+
+      responseObservers.forEach(updateResult::subscribe);
+    }
+
+    private void addNewUpdate(
+        EntityKey entityKey,
+        SingleObserver<Entity> observer,
+        UpsertCondition condition,
+        Duration maximumDelay) {
+      this.entityKey = entityKey;
+      this.condition = condition;
+      this.responseObservers.add(observer);
+      Instant newDeadline = EntityDataCachingClient.this.clock.instant().plus(maximumDelay);
+      if (isNull(currentDeadline) || this.currentDeadline.isAfter(newDeadline)) {
+        this.currentDeadline = newDeadline;
+        if (nonNull(updateExecutionTimer)) {
+          updateExecutionTimer.dispose();
+        }
+
+        this.updateExecutionTimer =
+            Completable.timer(maximumDelay.toNanos(), TimeUnit.NANOSECONDS)
+                .subscribe(this::executeUpdate);
+      }
+    }
   }
 }

--- a/entity-data-service-rx-client/src/main/java/org/hypertrace/entity/data/service/rxclient/EntityDataCachingClient.java
+++ b/entity-data-service-rx-client/src/main/java/org/hypertrace/entity/data/service/rxclient/EntityDataCachingClient.java
@@ -28,11 +28,8 @@ import org.hypertrace.entity.data.service.v1.EntityDataServiceGrpc.EntityDataSer
 import org.hypertrace.entity.data.service.v1.MergeAndUpsertEntityRequest;
 import org.hypertrace.entity.data.service.v1.MergeAndUpsertEntityRequest.UpsertCondition;
 import org.hypertrace.entity.data.service.v1.MergeAndUpsertEntityResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class EntityDataCachingClient implements EntityDataClient {
-  private static final Logger LOG = LoggerFactory.getLogger(EntityDataCachingClient.class);
   private final EntityDataServiceStub entityDataClient;
   private final LoadingCache<EntityKey, Single<Entity>> cache;
   private final ConcurrentMap<EntityKey, PendingEntityUpdate> pendingEntityUpdates =
@@ -81,7 +78,8 @@ class EntityDataCachingClient implements EntityDataClient {
     return this.createOrUpdateEntity(EntityKey.entityInCurrentContext(entity), upsertCondition);
   }
 
-  private Single<Entity> createOrUpdateEntity(EntityKey entityKey, UpsertCondition upsertCondition) {
+  private Single<Entity> createOrUpdateEntity(
+      EntityKey entityKey, UpsertCondition upsertCondition) {
     Single<Entity> updateResult =
         this.upsertEntityWithoutCaching(entityKey, upsertCondition).cache();
     EntityDataCachingClient.this.cache.put(entityKey, updateResult);
@@ -114,8 +112,6 @@ class EntityDataCachingClient implements EntityDataClient {
     private UpsertCondition condition;
 
     private void executeUpdate() {
-      LOG.warn(
-          "Executing update for {} at {}", entityKey.getInputEntity().getEntityId(), Instant.now());
 
       EntityDataCachingClient.this.pendingEntityUpdates.remove(entityKey);
 

--- a/entity-data-service-rx-client/src/main/java/org/hypertrace/entity/data/service/rxclient/EntityDataClient.java
+++ b/entity-data-service-rx-client/src/main/java/org/hypertrace/entity/data/service/rxclient/EntityDataClient.java
@@ -36,6 +36,20 @@ public interface EntityDataClient {
    * excessive overhead. Each returned single will propagate the result of the server call that
    * eventually satisfies its deadline.
    *
+   * <p>Example:
+   *
+   * <ol>
+   *   <li>entity-1.v1 arrives at t=0ms with a max delay of 500ms
+   *   <li>entity-1.v2 arrives at t=100ms with a max delay of 300ms
+   *   <li>entity-2.v1 arrives at t=200ms with a max delay of 300ms
+   *   <li>entity-1.v3 arrives at t=300ms with a max delay of 500ms
+   * </ol>
+   *
+   * At t=400ms (the deadline for the second invocation) entity-1 is upserted, using the most recent
+   * values (the fourth invocation - entity-1.v3). When this returns, the result will be given to
+   * the first, second and fourth invocations (the ones for that entity). At t=500ms, the deadline
+   * for the third invocation entity-2 is upserted and returned to the third invocation.
+   *
    * @param entity
    * @param upsertCondition
    * @param maximumUpsertDelay

--- a/entity-data-service-rx-client/src/main/java/org/hypertrace/entity/data/service/rxclient/EntityKey.java
+++ b/entity-data-service-rx-client/src/main/java/org/hypertrace/entity/data/service/rxclient/EntityKey.java
@@ -8,18 +8,17 @@ import javax.annotation.Nonnull;
 import org.hypertrace.core.grpcutils.client.rx.GrpcRxExecutionContext;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.entity.data.service.v1.Entity;
-import org.hypertrace.entity.v1.entitytype.EntityType;
 
 /**
  * Caches based on the tenant id, entity type and entity id if available. If entity id is not
  * available, the key falls back to an equality comparison of the identifying attributes map.
  */
-class EntityCacheKey {
+class EntityKey {
 
   private static final String DEFAULT_TENANT_ID = "default";
 
-  static EntityCacheKey entityInCurrentContext(Entity inputEntity) {
-    return new EntityCacheKey(
+  static EntityKey entityInCurrentContext(Entity inputEntity) {
+    return new EntityKey(
         requireNonNull(RequestContext.CURRENT.get()), requireNonNull(inputEntity));
   }
 
@@ -34,7 +33,7 @@ class EntityCacheKey {
                       ? entity.getIdentifyingAttributesMap()
                       : entity.getEntityId());
 
-  protected EntityCacheKey(@Nonnull RequestContext requestContext, @Nonnull Entity inputEntity) {
+  protected EntityKey(@Nonnull RequestContext requestContext, @Nonnull Entity inputEntity) {
     requireNonNull(inputEntity.getEntityId());
     requireNonNull(inputEntity.getEntityType());
     this.executionContext = GrpcRxExecutionContext.forContext(requestContext);
@@ -58,7 +57,7 @@ class EntityCacheKey {
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    EntityCacheKey that = (EntityCacheKey) o;
+    EntityKey that = (EntityKey) o;
     return tenantId.equals(that.tenantId)
         && getEntityType().equals(that.getEntityType())
         && ENTITY_EQUIVALENCE.equivalent(getInputEntity(), that.getInputEntity());

--- a/entity-data-service-rx-client/src/test/java/org/hypertrace/entity/data/service/rxclient/EntityDataCachingClientTest.java
+++ b/entity-data-service-rx-client/src/test/java/org/hypertrace/entity/data/service/rxclient/EntityDataCachingClientTest.java
@@ -1,13 +1,16 @@
 package org.hypertrace.entity.data.service.rxclient;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
@@ -18,12 +21,21 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.stub.StreamObserver;
+import io.reactivex.rxjava3.observers.TestObserver;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+import io.reactivex.rxjava3.schedulers.TestScheduler;
 import java.io.IOException;
+import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.entity.data.service.v1.Entity;
 import org.hypertrace.entity.data.service.v1.EntityDataServiceGrpc.EntityDataServiceImplBase;
+import org.hypertrace.entity.data.service.v1.MergeAndUpsertEntityRequest;
+import org.hypertrace.entity.data.service.v1.MergeAndUpsertEntityRequest.UpsertCondition;
+import org.hypertrace.entity.data.service.v1.MergeAndUpsertEntityResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,6 +64,7 @@ class EntityDataCachingClientTest {
   Context grpcTestContext;
   List<Entity> possibleResponseEntities;
   Optional<Throwable> responseError;
+  TestScheduler testScheduler;
 
   @BeforeEach
   void beforeEach() throws IOException {
@@ -70,27 +83,37 @@ class EntityDataCachingClientTest {
     this.responseError = Optional.empty();
     doAnswer(
             invocation -> {
-              StreamObserver<Entity> observer = invocation.getArgument(1, StreamObserver.class);
-              Entity inputEntity = invocation.getArgument(0, Entity.class);
+              StreamObserver<MergeAndUpsertEntityResponse> observer =
+                  invocation.getArgument(1, StreamObserver.class);
+              Entity inputEntity =
+                  invocation.getArgument(0, MergeAndUpsertEntityRequest.class).getEntity();
               responseError.ifPresentOrElse(
                   observer::onError,
                   () -> {
                     observer.onNext(
-                        this.possibleResponseEntities.stream()
-                            .filter(
-                                entity -> entity.getEntityId().equals(inputEntity.getEntityId()))
-                            .findFirst()
-                            .orElse(inputEntity));
+                        MergeAndUpsertEntityResponse.newBuilder()
+                            .setEntity(
+                                this.possibleResponseEntities.stream()
+                                    .filter(
+                                        entity ->
+                                            entity.getEntityId().equals(inputEntity.getEntityId()))
+                                    .findFirst()
+                                    .orElse(inputEntity))
+                            .build());
                     observer.onCompleted();
                   });
               return null;
             })
         .when(this.mockDataService)
-        .upsert(any(), any());
+        .mergeAndUpsertEntity(any(), any());
+    this.testScheduler = new TestScheduler();
+    RxJavaPlugins.setComputationSchedulerHandler(ignored -> testScheduler);
   }
 
   @AfterEach
   void afterEach() {
+    // Reset
+    RxJavaPlugins.setComputationSchedulerHandler(null);
     this.grpcServer.shutdownNow();
     this.grpcChannel.shutdownNow();
   }
@@ -103,7 +126,7 @@ class EntityDataCachingClientTest {
         this.grpcTestContext.call(
             () -> this.dataClient.getOrCreateEntity(inputEntity).blockingGet()));
 
-    verify(this.mockDataService, times(1)).upsert(any(), any());
+    verify(this.mockDataService, times(1)).mergeAndUpsertEntity(any(), any());
     verifyNoMoreInteractions(this.mockDataService);
     assertSame(
         this.defaultResponseEntity,
@@ -118,7 +141,7 @@ class EntityDataCachingClientTest {
         this.grpcTestContext.call(
             () -> this.dataClient.getOrCreateEntity(inputEntity).blockingGet());
     assertSame(this.defaultResponseEntity, defaultRetrieved);
-    verify(this.mockDataService, times(1)).upsert(any(), any());
+    verify(this.mockDataService, times(1)).mergeAndUpsertEntity(any(), any());
 
     RequestContext otherMockContext = mock(RequestContext.class);
     when(otherMockContext.getTenantId()).thenReturn(Optional.of("other tenant"));
@@ -133,7 +156,7 @@ class EntityDataCachingClientTest {
         otherGrpcContext.call(() -> this.dataClient.getOrCreateEntity(inputEntity).blockingGet());
     assertSame(otherEntityResponse, otherRetrieved);
     assertNotSame(defaultRetrieved, otherRetrieved);
-    verify(this.mockDataService, times(2)).upsert(any(), any());
+    verify(this.mockDataService, times(2)).mergeAndUpsertEntity(any(), any());
     verifyNoMoreInteractions(this.mockDataService);
 
     assertSame(
@@ -156,14 +179,14 @@ class EntityDataCachingClientTest {
         () ->
             this.grpcTestContext.call(
                 () -> this.dataClient.getOrCreateEntity(inputEntity).blockingGet()));
-    verify(this.mockDataService, times(1)).upsert(any(), any());
+    verify(this.mockDataService, times(1)).mergeAndUpsertEntity(any(), any());
 
     this.responseError = Optional.empty();
     assertSame(
         this.defaultResponseEntity,
         this.grpcTestContext.call(
             () -> this.dataClient.getOrCreateEntity(inputEntity).blockingGet()));
-    verify(this.mockDataService, times(2)).upsert(any(), any());
+    verify(this.mockDataService, times(2)).mergeAndUpsertEntity(any(), any());
   }
 
   @Test
@@ -184,6 +207,93 @@ class EntityDataCachingClientTest {
     // Rerunning this call now fire again, a third server call
     this.grpcTestContext.call(
         () -> this.dataClient.getOrCreateEntity(this.defaultResponseEntity).blockingGet());
-    verify(this.mockDataService, times(3)).upsert(any(), any());
+    verify(this.mockDataService, times(3)).mergeAndUpsertEntity(any(), any());
+  }
+
+  @Test
+  void createOrUpdateCallsUpsert() throws Exception {
+    assertSame(
+        this.defaultResponseEntity,
+        this.grpcTestContext.call(
+            () ->
+                this.dataClient
+                    .createOrUpdateEntity(
+                        this.defaultResponseEntity, UpsertCondition.getDefaultInstance())
+                    .blockingGet()));
+
+    verify(this.mockDataService, times(1))
+        .mergeAndUpsertEntity(
+            eq(
+                MergeAndUpsertEntityRequest.newBuilder()
+                    .setEntity(this.defaultResponseEntity)
+                    .setUpsertCondition(UpsertCondition.getDefaultInstance())
+                    .build()),
+            any());
+  }
+
+  @Test
+  void createOrUpdateEventuallyThrottlesAndUsesLastProvidedValue() throws Exception {
+    TestObserver<Entity> firstObserver = new TestObserver<>();
+    TestObserver<Entity> secondObserver = new TestObserver<>();
+    TestObserver<Entity> thirdObserver = new TestObserver<>();
+    this.possibleResponseEntities = Collections.emptyList(); // Just reflect entities in this test
+    Entity firstEntity = this.defaultResponseEntity.toBuilder().setEntityName("first name").build();
+    Entity secondEntity =
+        this.defaultResponseEntity.toBuilder().setEntityName("second name").build();
+    Entity thirdEntity = this.defaultResponseEntity.toBuilder().setEntityName("third name").build();
+    this.grpcTestContext.run(
+        () ->
+            this.dataClient
+                .createOrUpdateEntityEventually(
+                    firstEntity, UpsertCondition.getDefaultInstance(), Duration.ofMillis(1000))
+                .subscribe(firstObserver));
+
+    testScheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
+    this.grpcTestContext.run(
+        () ->
+            this.dataClient
+                .createOrUpdateEntityEventually(
+                    secondEntity, UpsertCondition.getDefaultInstance(), Duration.ofMillis(200))
+                .subscribe(secondObserver));
+
+    testScheduler.advanceTimeBy(150, TimeUnit.MILLISECONDS);
+
+    this.grpcTestContext.run(
+        () ->
+            this.dataClient
+                .createOrUpdateEntityEventually(
+                    thirdEntity, UpsertCondition.getDefaultInstance(), Duration.ofMillis(5000))
+                .subscribe(thirdObserver));
+
+    testScheduler.advanceTimeBy(49, TimeUnit.MILLISECONDS);
+
+    // All 3 should complete at 500ms (we're currently at 499ms)
+    verifyNoInteractions(this.mockDataService);
+    firstObserver.assertNotComplete().assertNoErrors().assertNoValues();
+    secondObserver.assertNotComplete().assertNoErrors().assertNoValues();
+    thirdObserver.assertNotComplete().assertNoErrors().assertNoValues();
+
+    testScheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
+
+    verify(this.mockDataService, times(1))
+        .mergeAndUpsertEntity(
+            eq(
+                MergeAndUpsertEntityRequest.newBuilder()
+                    .setEntity(thirdEntity)
+                    .setUpsertCondition(UpsertCondition.getDefaultInstance())
+                    .build()),
+            any());
+
+    firstObserver.assertResult(thirdEntity);
+    secondObserver.assertResult(thirdEntity);
+    thirdObserver.assertResult(thirdEntity);
+
+    // Result should be in cache now, let's try to fetch and verify no server call
+    Entity fetchedEntity =
+        this.grpcTestContext.call(
+            () -> this.dataClient.getOrCreateEntity(firstEntity).blockingGet());
+
+    assertEquals(thirdEntity, fetchedEntity);
+    verifyNoMoreInteractions(this.mockDataService);
   }
 }

--- a/entity-data-service-rx-client/src/test/java/org/hypertrace/entity/data/service/rxclient/EntityKeyTest.java
+++ b/entity-data-service-rx-client/src/test/java/org/hypertrace/entity/data/service/rxclient/EntityKeyTest.java
@@ -16,7 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class EntityCacheKeyTest {
+class EntityKeyTest {
 
   @Mock RequestContext mockRequestContext;
 
@@ -46,8 +46,8 @@ class EntityCacheKeyTest {
     Entity matchingEntity = this.entityV2.toBuilder().clearAttributes().build();
 
     assertEquals(
-        new EntityCacheKey(this.mockRequestContext, this.entityV2),
-        new EntityCacheKey(matchingContext, matchingEntity));
+        new EntityKey(this.mockRequestContext, this.entityV2),
+        new EntityKey(matchingContext, matchingEntity));
   }
 
   @Test
@@ -56,8 +56,8 @@ class EntityCacheKeyTest {
     when(this.mockRequestContext.getTenantId()).thenReturn(Optional.of("tenant id 1"));
     when(differentContext.getTenantId()).thenReturn(Optional.of("tenant id 2"));
     assertNotEquals(
-        new EntityCacheKey(this.mockRequestContext, this.entityV2),
-        new EntityCacheKey(differentContext, this.entityV2));
+        new EntityKey(this.mockRequestContext, this.entityV2),
+        new EntityKey(differentContext, this.entityV2));
   }
 
   @Test
@@ -66,8 +66,8 @@ class EntityCacheKeyTest {
     Entity differentEntity = this.entityV2.toBuilder().setEntityId("id-2").build();
 
     assertNotEquals(
-        new EntityCacheKey(this.mockRequestContext, this.entityV2),
-        new EntityCacheKey(this.mockRequestContext, differentEntity));
+        new EntityKey(this.mockRequestContext, this.entityV2),
+        new EntityKey(this.mockRequestContext, differentEntity));
   }
 
   @Test
@@ -80,8 +80,8 @@ class EntityCacheKeyTest {
     Entity matchingEntity = this.entityV1.toBuilder().clearAttributes().build();
 
     assertEquals(
-        new EntityCacheKey(this.mockRequestContext, this.entityV1),
-        new EntityCacheKey(matchingContext, matchingEntity));
+        new EntityKey(this.mockRequestContext, this.entityV1),
+        new EntityKey(matchingContext, matchingEntity));
   }
 
   @Test
@@ -92,8 +92,8 @@ class EntityCacheKeyTest {
         this.entityV1.toBuilder().putIdentifyingAttributes("key-2", buildValue("value-2")).build();
 
     assertNotEquals(
-        new EntityCacheKey(this.mockRequestContext, this.entityV1),
-        new EntityCacheKey(this.mockRequestContext, diffEntity));
+        new EntityKey(this.mockRequestContext, this.entityV1),
+        new EntityKey(this.mockRequestContext, diffEntity));
   }
 
   @Test
@@ -103,8 +103,8 @@ class EntityCacheKeyTest {
     when(otherContext.getTenantId()).thenReturn(Optional.of("tenant id 2"));
 
     assertNotEquals(
-        new EntityCacheKey(this.mockRequestContext, this.entityV1),
-        new EntityCacheKey(otherContext, this.entityV1));
+        new EntityKey(this.mockRequestContext, this.entityV1),
+        new EntityKey(otherContext, this.entityV1));
   }
 
   private static AttributeValue buildValue(String value) {


### PR DESCRIPTION
## Description
This new client api allows throttling writes. This allows ingestion to write at high volume, while only periodically pushing those changes to the server.

### Testing
Tested E2E, added UT

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
