### PR TITLE
fix: write timestamp attribute key

### DIFF
--- a/entity-service-impl/src/main/java/org/hypertrace/entity/type/service/v2/model/EntityTypeDocument.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/type/service/v2/model/EntityTypeDocument.java
@@ -28,6 +28,8 @@ public class EntityTypeDocument implements Document {
 
   @JsonProperty private String nameAttributeKey;
 
+  @JsonProperty private String timestampAttributeKey;
+
   public EntityTypeDocument() {}
 
   public EntityTypeDocument(
@@ -35,12 +37,14 @@ public class EntityTypeDocument implements Document {
       String name,
       String attributeScope,
       String idAttributeKey,
-      String nameAttributeKey) {
+      String nameAttributeKey,
+      String timestampAttributeKey) {
     this.tenantId = tenantId;
     this.name = name;
     this.attributeScope = attributeScope;
     this.idAttributeKey = idAttributeKey;
     this.nameAttributeKey = nameAttributeKey;
+    this.timestampAttributeKey = timestampAttributeKey;
   }
 
   public static EntityTypeDocument fromProto(@Nonnull String tenantId, EntityType entityType) {
@@ -49,7 +53,8 @@ public class EntityTypeDocument implements Document {
         entityType.getName(),
         entityType.getAttributeScope(),
         entityType.getIdAttributeKey(),
-        entityType.getNameAttributeKey());
+        entityType.getNameAttributeKey(),
+        entityType.getTimestampAttributeKey());
   }
 
   public EntityType toProto() {
@@ -58,6 +63,7 @@ public class EntityTypeDocument implements Document {
         .setAttributeScope(getAttributeScope())
         .setIdAttributeKey(getIdAttributeKey())
         .setNameAttributeKey(getNameAttributeKey())
+        .setTimestampAttributeKey(getTimestampAttributeKey())
         .build();
   }
 
@@ -85,24 +91,16 @@ public class EntityTypeDocument implements Document {
     return attributeScope;
   }
 
-  public void setAttributeScope(String attributeScope) {
-    this.attributeScope = attributeScope;
-  }
-
   public String getIdAttributeKey() {
     return idAttributeKey;
-  }
-
-  public void setIdAttributeKey(String idAttributeKey) {
-    this.idAttributeKey = idAttributeKey;
   }
 
   public String getNameAttributeKey() {
     return nameAttributeKey;
   }
 
-  public void setNameAttributeKey(String nameAttributeKey) {
-    this.nameAttributeKey = nameAttributeKey;
+  public String getTimestampAttributeKey() {
+    return timestampAttributeKey;
   }
 
   @Override
@@ -118,12 +116,14 @@ public class EntityTypeDocument implements Document {
         && Objects.equals(name, document.name)
         && Objects.equals(attributeScope, document.attributeScope)
         && Objects.equals(idAttributeKey, document.idAttributeKey)
-        && Objects.equals(nameAttributeKey, document.nameAttributeKey);
+        && Objects.equals(nameAttributeKey, document.nameAttributeKey)
+        && Objects.equals(timestampAttributeKey, document.timestampAttributeKey);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(tenantId, name, attributeScope, idAttributeKey, nameAttributeKey);
+    return Objects.hash(
+        tenantId, name, attributeScope, idAttributeKey, nameAttributeKey, timestampAttributeKey);
   }
 
   @Override

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/type/service/v2/model/EntityTypeDocumentTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/type/service/v2/model/EntityTypeDocumentTest.java
@@ -15,6 +15,7 @@ public class EntityTypeDocumentTest {
             .setAttributeScope("API")
             .setIdAttributeKey("id")
             .setNameAttributeKey("name")
+            .setTimestampAttributeKey("timestamp")
             .build();
     Assertions.assertEquals(
         entityType, EntityTypeDocument.fromProto("testTenant", entityType).toProto());
@@ -22,7 +23,8 @@ public class EntityTypeDocumentTest {
 
   @Test
   public void testJsonConversion() throws JsonProcessingException {
-    EntityTypeDocument document = new EntityTypeDocument("testTenant", "API", "API", "id", "name");
+    EntityTypeDocument document =
+        new EntityTypeDocument("testTenant", "API", "API", "id", "name", "timestamp");
     Assertions.assertEquals(document, EntityTypeDocument.fromJson(document.toJson()));
   }
 }


### PR DESCRIPTION
## Description

Write timestamp attribute key to database. Without this change it was being silently ignored. This was missed because the key is not needed for querying - it's currently only used for optimistic locking, which is just skipped if it's not set - so no visible difference.

### Testing
Verified after adding that this key was being written.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

