### PR TITLE
fix: backwards compat for existing entity type docs

### DIFF
--- a/entity-service-impl/src/main/java/org/hypertrace/entity/type/service/v2/model/EntityTypeDocument.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/type/service/v2/model/EntityTypeDocument.java
@@ -1,10 +1,12 @@
 package org.hypertrace.entity.type.service.v2.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Objects;
+import java.util.Optional;
 import javax.annotation.Nonnull;
 import org.hypertrace.core.documentstore.Document;
 import org.hypertrace.entity.service.constants.EntityServiceConstants;
@@ -58,13 +60,16 @@ public class EntityTypeDocument implements Document {
   }
 
   public EntityType toProto() {
-    return EntityType.newBuilder()
-        .setName(getName())
-        .setAttributeScope(getAttributeScope())
-        .setIdAttributeKey(getIdAttributeKey())
-        .setNameAttributeKey(getNameAttributeKey())
-        .setTimestampAttributeKey(getTimestampAttributeKey())
-        .build();
+    EntityType.Builder builder =
+        EntityType.newBuilder()
+            .setName(getName())
+            .setAttributeScope(getAttributeScope())
+            .setIdAttributeKey(getIdAttributeKey());
+
+    getNameAttributeKey().ifPresent(builder::setNameAttributeKey);
+    getTimestampAttributeKey().ifPresent(builder::setTimestampAttributeKey);
+
+    return builder.build();
   }
 
   public static EntityTypeDocument fromJson(String json) throws JsonProcessingException {
@@ -95,12 +100,14 @@ public class EntityTypeDocument implements Document {
     return idAttributeKey;
   }
 
-  public String getNameAttributeKey() {
-    return nameAttributeKey;
+  @JsonIgnore
+  public Optional<String> getNameAttributeKey() {
+    return Optional.of(nameAttributeKey);
   }
 
-  public String getTimestampAttributeKey() {
-    return timestampAttributeKey;
+  @JsonIgnore
+  public Optional<String> getTimestampAttributeKey() {
+    return Optional.ofNullable(timestampAttributeKey);
   }
 
   @Override

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/type/service/v2/model/EntityTypeDocumentTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/type/service/v2/model/EntityTypeDocumentTest.java
@@ -1,6 +1,8 @@
 package org.hypertrace.entity.type.service.v2.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
 import org.hypertrace.entity.type.service.v2.EntityType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -26,5 +28,33 @@ public class EntityTypeDocumentTest {
     EntityTypeDocument document =
         new EntityTypeDocument("testTenant", "API", "API", "id", "name", "timestamp");
     Assertions.assertEquals(document, EntityTypeDocument.fromJson(document.toJson()));
+  }
+
+  @Test
+  public void testFromJsonMissingField()
+      throws InvalidProtocolBufferException, JsonProcessingException {
+    EntityType entityType =
+        EntityType.newBuilder()
+            .setName("API")
+            .setAttributeScope("API")
+            .setIdAttributeKey("id")
+            .setNameAttributeKey("name")
+            .build();
+    String entityTypeJson = JsonFormat.printer().print(entityType);
+    Assertions.assertEquals(entityType, EntityTypeDocument.fromJson(entityTypeJson).toProto());
+  }
+
+  @Test
+  public void testToProtoMissingField() {
+    EntityTypeDocument document =
+        new EntityTypeDocument("testTenant", "API", "API", "id", "name", null);
+    Assertions.assertEquals(
+        EntityType.newBuilder()
+            .setName("API")
+            .setAttributeScope("API")
+            .setIdAttributeKey("id")
+            .setNameAttributeKey("name")
+            .build(),
+        document.toProto());
   }
 }


### PR DESCRIPTION
## Description
Make name and timestamp keys optional - both to support backwards compatibility but also for entity definitions that don't use those fields.

### Testing
Ran into issues with previous rev in e2e env due to existing upgrades that missed the new key. Now making it optional.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
