### PR TITLE
feat: add support for required keys on entity attributes

### DIFF
--- a/entity-service-api/src/main/proto/org/hypertrace/entity/type/service/v2/entity_type_service.proto
+++ b/entity-service-api/src/main/proto/org/hypertrace/entity/type/service/v2/entity_type_service.proto
@@ -9,6 +9,7 @@ message EntityType {
   string id_attribute_key = 3;
   string name_attribute_key = 4;
   string timestamp_attribute_key = 5;
+  repeated string required_keys = 6;
 }
 
 message UpsertEntityTypeRequest {

--- a/entity-service-api/src/main/proto/org/hypertrace/entity/type/service/v2/entity_type_service.proto
+++ b/entity-service-api/src/main/proto/org/hypertrace/entity/type/service/v2/entity_type_service.proto
@@ -9,7 +9,13 @@ message EntityType {
   string id_attribute_key = 3;
   string name_attribute_key = 4;
   string timestamp_attribute_key = 5;
-  repeated string required_keys = 6;
+  repeated EntityFormationCondition required_conditions = 6;
+
+  message EntityFormationCondition {
+    oneof condition {
+      string required_key = 1;
+    }
+  }
 }
 
 message UpsertEntityTypeRequest {
@@ -24,7 +30,8 @@ message DeleteEntityTypesRequest {
   repeated string name = 1;
 }
 
-message DeleteEntityTypesResponse {}
+message DeleteEntityTypesResponse {
+}
 
 message QueryEntityTypesRequest {
   repeated string name = 1;
@@ -35,7 +42,10 @@ message QueryEntityTypesResponse {
 }
 
 service EntityTypeService {
-  rpc UpsertEntityType (UpsertEntityTypeRequest) returns (UpsertEntityTypeResponse) {}
-  rpc DeleteEntityTypes (DeleteEntityTypesRequest) returns (DeleteEntityTypesResponse) {}
-  rpc QueryEntityTypes (QueryEntityTypesRequest) returns (QueryEntityTypesResponse) {}
+  rpc UpsertEntityType (UpsertEntityTypeRequest) returns (UpsertEntityTypeResponse) {
+  }
+  rpc DeleteEntityTypes (DeleteEntityTypesRequest) returns (DeleteEntityTypesResponse) {
+  }
+  rpc QueryEntityTypes (QueryEntityTypesRequest) returns (QueryEntityTypesResponse) {
+  }
 }

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/type/service/v2/model/EntityTypeDocument.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/type/service/v2/model/EntityTypeDocument.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nonnull;
@@ -32,21 +34,25 @@ public class EntityTypeDocument implements Document {
 
   @JsonProperty private String timestampAttributeKey;
 
+  @JsonProperty private List<String> requiredKeys;
+
   public EntityTypeDocument() {}
 
-  public EntityTypeDocument(
+  EntityTypeDocument(
       String tenantId,
       String name,
       String attributeScope,
       String idAttributeKey,
       String nameAttributeKey,
-      String timestampAttributeKey) {
+      String timestampAttributeKey,
+      List<String> requiredKeys) {
     this.tenantId = tenantId;
     this.name = name;
     this.attributeScope = attributeScope;
     this.idAttributeKey = idAttributeKey;
     this.nameAttributeKey = nameAttributeKey;
     this.timestampAttributeKey = timestampAttributeKey;
+    this.requiredKeys = requiredKeys;
   }
 
   public static EntityTypeDocument fromProto(@Nonnull String tenantId, EntityType entityType) {
@@ -56,7 +62,8 @@ public class EntityTypeDocument implements Document {
         entityType.getAttributeScope(),
         entityType.getIdAttributeKey(),
         entityType.getNameAttributeKey(),
-        entityType.getTimestampAttributeKey());
+        entityType.getTimestampAttributeKey(),
+        entityType.getRequiredKeysList());
   }
 
   public EntityType toProto() {
@@ -64,11 +71,11 @@ public class EntityTypeDocument implements Document {
         EntityType.newBuilder()
             .setName(getName())
             .setAttributeScope(getAttributeScope())
-            .setIdAttributeKey(getIdAttributeKey());
+            .setIdAttributeKey(getIdAttributeKey())
+            .addAllRequiredKeys(getRequiredKeys());
 
     getNameAttributeKey().ifPresent(builder::setNameAttributeKey);
     getTimestampAttributeKey().ifPresent(builder::setTimestampAttributeKey);
-
     return builder.build();
   }
 
@@ -110,27 +117,34 @@ public class EntityTypeDocument implements Document {
     return Optional.ofNullable(timestampAttributeKey);
   }
 
+  public List<String> getRequiredKeys() {
+    return Optional.ofNullable(requiredKeys).orElse(Collections.emptyList());
+  }
+
   @Override
   public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    EntityTypeDocument document = (EntityTypeDocument) o;
-    return Objects.equals(tenantId, document.tenantId)
-        && Objects.equals(name, document.name)
-        && Objects.equals(attributeScope, document.attributeScope)
-        && Objects.equals(idAttributeKey, document.idAttributeKey)
-        && Objects.equals(nameAttributeKey, document.nameAttributeKey)
-        && Objects.equals(timestampAttributeKey, document.timestampAttributeKey);
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    EntityTypeDocument that = (EntityTypeDocument) o;
+    return Objects.equals(getTenantId(), that.getTenantId())
+        && Objects.equals(getName(), that.getName())
+        && Objects.equals(getAttributeScope(), that.getAttributeScope())
+        && Objects.equals(getIdAttributeKey(), that.getIdAttributeKey())
+        && Objects.equals(getNameAttributeKey(), that.getNameAttributeKey())
+        && Objects.equals(getTimestampAttributeKey(), that.getTimestampAttributeKey())
+        && Objects.equals(getRequiredKeys(), that.getRequiredKeys());
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        tenantId, name, attributeScope, idAttributeKey, nameAttributeKey, timestampAttributeKey);
+        getTenantId(),
+        getName(),
+        getAttributeScope(),
+        getIdAttributeKey(),
+        getNameAttributeKey(),
+        getTimestampAttributeKey(),
+        getRequiredKeys());
   }
 
   @Override

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/type/service/v2/model/EntityTypeDocumentTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/type/service/v2/model/EntityTypeDocumentTest.java
@@ -5,6 +5,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
 import java.util.List;
 import org.hypertrace.entity.type.service.v2.EntityType;
+import org.hypertrace.entity.type.service.v2.EntityType.EntityFormationCondition;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -19,7 +20,7 @@ public class EntityTypeDocumentTest {
             .setIdAttributeKey("id")
             .setNameAttributeKey("name")
             .setTimestampAttributeKey("timestamp")
-            .addRequiredKeys("other")
+            .addRequiredConditions(EntityFormationCondition.newBuilder().setRequiredKey("other"))
             .build();
     Assertions.assertEquals(
         entityType, EntityTypeDocument.fromProto("testTenant", entityType).toProto());
@@ -29,7 +30,13 @@ public class EntityTypeDocumentTest {
   public void testJsonConversion() throws JsonProcessingException {
     EntityTypeDocument document =
         new EntityTypeDocument(
-            "testTenant", "API", "API", "id", "name", "timestamp", List.of("other"));
+            "testTenant",
+            "API",
+            "API",
+            "id",
+            "name",
+            "timestamp",
+            List.of(EntityFormationCondition.newBuilder().setRequiredKey("other").build()));
     Assertions.assertEquals(document, EntityTypeDocument.fromJson(document.toJson()));
   }
 

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/type/service/v2/model/EntityTypeDocumentTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/type/service/v2/model/EntityTypeDocumentTest.java
@@ -3,6 +3,7 @@ package org.hypertrace.entity.type.service.v2.model;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
+import java.util.List;
 import org.hypertrace.entity.type.service.v2.EntityType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -18,6 +19,7 @@ public class EntityTypeDocumentTest {
             .setIdAttributeKey("id")
             .setNameAttributeKey("name")
             .setTimestampAttributeKey("timestamp")
+            .addRequiredKeys("other")
             .build();
     Assertions.assertEquals(
         entityType, EntityTypeDocument.fromProto("testTenant", entityType).toProto());
@@ -26,7 +28,8 @@ public class EntityTypeDocumentTest {
   @Test
   public void testJsonConversion() throws JsonProcessingException {
     EntityTypeDocument document =
-        new EntityTypeDocument("testTenant", "API", "API", "id", "name", "timestamp");
+        new EntityTypeDocument(
+            "testTenant", "API", "API", "id", "name", "timestamp", List.of("other"));
     Assertions.assertEquals(document, EntityTypeDocument.fromJson(document.toJson()));
   }
 
@@ -47,7 +50,7 @@ public class EntityTypeDocumentTest {
   @Test
   public void testToProtoMissingField() {
     EntityTypeDocument document =
-        new EntityTypeDocument("testTenant", "API", "API", "id", "name", null);
+        new EntityTypeDocument("testTenant", "API", "API", "id", "name", null, null);
     Assertions.assertEquals(
         EntityType.newBuilder()
             .setName("API")


### PR DESCRIPTION
## Description
This adds support for requiring keys on v2 entity types that are ingested based on config during enrichment. Previously, any time a valid ID can be generated, an entity would be formed (so, for example, if an id is based on a hash of several attributes and only one is present, it would still form an entity). Now, we can require any number of attributes to be present to give more control over entity definition. A better version of this would be full blown predicate support, but given that entity type service doesn't have those constructs today, it felt like overkill to build that out just yet... instead, I wrapped the concept such that other types of conditions could be added in the future.

### Testing
Updated UTs, validated behavior e2e

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
