### PR TITLE
EdsCache Client Metrics

### DIFF
--- a/entity-service-client/build.gradle.kts
+++ b/entity-service-client/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
 
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.4.0")
   implementation("org.slf4j:slf4j-api:1.7.30")
+  implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.28")
 
   testImplementation("io.grpc:grpc-core:1.36.1")
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")

--- a/entity-service-client/src/main/java/org/hypertrace/entity/data/service/client/EdsCacheClient.java
+++ b/entity-service-client/src/main/java/org/hypertrace/entity/data/service/client/EdsCacheClient.java
@@ -4,12 +4,14 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
+import org.hypertrace.core.serviceframework.metrics.PlatformMetricsRegistry;
 import org.hypertrace.entity.data.service.client.exception.NotFoundException;
 import org.hypertrace.entity.data.service.v1.ByTypeAndIdentifyingAttributes;
 import org.hypertrace.entity.data.service.v1.EnrichedEntities;
@@ -42,6 +44,7 @@ public class EdsCacheClient implements EdsClient {
         CacheBuilder.newBuilder()
             .expireAfterWrite(cacheConfig.getEnrichedEntityCacheExpiryMs(), TimeUnit.MILLISECONDS)
             .maximumSize(cacheConfig.getEnrichedEntityMaxCacheSize())
+            .recordStats()
             .build(
                 new CacheLoader<>() {
                   public EnrichedEntity load(@Nonnull EdsCacheKey key) throws Exception {
@@ -58,6 +61,7 @@ public class EdsCacheClient implements EdsClient {
         CacheBuilder.newBuilder()
             .expireAfterWrite(cacheConfig.getEntityCacheExpiryMs(), TimeUnit.MILLISECONDS)
             .maximumSize(cacheConfig.getEntityMaxCacheSize())
+            .recordStats()
             .build(
                 new CacheLoader<>() {
                   public Entity load(@Nonnull EdsCacheKey key) throws Exception {
@@ -73,6 +77,7 @@ public class EdsCacheClient implements EdsClient {
         CacheBuilder.newBuilder()
             .expireAfterWrite(cacheConfig.getEntityIdsCacheExpiryMs(), TimeUnit.MILLISECONDS)
             .maximumSize(cacheConfig.getEntityIdsMaxCacheSize())
+            .recordStats()
             .build(
                 new CacheLoader<>() {
                   public String load(@Nonnull EdsTypeAndIdAttributesCacheKey key) throws Exception {
@@ -87,6 +92,13 @@ public class EdsCacheClient implements EdsClient {
                     return entity.getEntityId();
                   }
                 });
+    PlatformMetricsRegistry.registerCache(
+        "enrichedEntityCache", enrichedEntityCache, Collections.emptyMap());
+    PlatformMetricsRegistry.registerCache(
+        "entityCache", entityCache, Collections.emptyMap());
+    PlatformMetricsRegistry.registerCache(
+        "entityIdsCache", entityIdsCache, Collections.emptyMap());
+
   }
 
   @Override

--- a/entity-service-client/src/main/java/org/hypertrace/entity/data/service/client/EdsCacheClient.java
+++ b/entity-service-client/src/main/java/org/hypertrace/entity/data/service/client/EdsCacheClient.java
@@ -94,11 +94,8 @@ public class EdsCacheClient implements EdsClient {
                 });
     PlatformMetricsRegistry.registerCache(
         "enrichedEntityCache", enrichedEntityCache, Collections.emptyMap());
-    PlatformMetricsRegistry.registerCache(
-        "entityCache", entityCache, Collections.emptyMap());
-    PlatformMetricsRegistry.registerCache(
-        "entityIdsCache", entityIdsCache, Collections.emptyMap());
-
+    PlatformMetricsRegistry.registerCache("entityCache", entityCache, Collections.emptyMap());
+    PlatformMetricsRegistry.registerCache("entityIdsCache", entityIdsCache, Collections.emptyMap());
   }
 
   @Override


### PR DESCRIPTION
## Description
Currently we have no metrics for the various cache used in EdsCacheClient. 
Adding metrics for them.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
The metrics are directly exported to Prometheus. Hence, there are no tests performed for this. Since the tests for the meter registry are already is place in the service-framework.

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
