### PR TITLE
fix: threading issue in entity caching client

### DIFF
--- a/entity-data-service-rx-client/src/main/java/org/hypertrace/entity/data/service/rxclient/EntityDataCachingClient.java
+++ b/entity-data-service-rx-client/src/main/java/org/hypertrace/entity/data/service/rxclient/EntityDataCachingClient.java
@@ -136,6 +136,10 @@ class EntityDataCachingClient implements EntityDataClient {
         SingleObserver<Entity> observer,
         UpsertCondition condition,
         Duration maximumDelay) {
+      if (updateExecutionTimer.isDisposed()) {
+        throw new IllegalStateException("Attempting to add new update after execution");
+      }
+
       this.entityKey = entityKey;
       this.condition = condition;
       this.responseObservers.add(observer);

--- a/entity-data-service-rx-client/src/main/java/org/hypertrace/entity/data/service/rxclient/EntityDataCachingClient.java
+++ b/entity-data-service-rx-client/src/main/java/org/hypertrace/entity/data/service/rxclient/EntityDataCachingClient.java
@@ -136,7 +136,7 @@ class EntityDataCachingClient implements EntityDataClient {
         SingleObserver<Entity> observer,
         UpsertCondition condition,
         Duration maximumDelay) {
-      if (updateExecutionTimer.isDisposed()) {
+      if (nonNull(updateExecutionTimer) && updateExecutionTimer.isDisposed()) {
         throw new IllegalStateException("Attempting to add new update after execution");
       }
 


### PR DESCRIPTION
## Description
previously, a pending update could be retrieved and modified after it
has started updating, causing it to npe and leak memory
