### PR TITLE
fix: address more concurrency concerns in caching client

### DIFF
--- a/entity-data-service-rx-client/src/main/java/org/hypertrace/entity/data/service/rxclient/EntityDataCachingClient.java
+++ b/entity-data-service-rx-client/src/main/java/org/hypertrace/entity/data/service/rxclient/EntityDataCachingClient.java
@@ -130,7 +130,6 @@ class EntityDataCachingClient implements EntityDataClient {
       }
       Single<Entity> updateResult =
           EntityDataCachingClient.this.createOrUpdateEntity(entityKey, condition).cache();
-      EntityDataCachingClient.this.cache.put(entityKey, updateResult);
 
       responseObservers.forEach(updateResult::subscribe);
     }


### PR DESCRIPTION
## Description
Switching from a RW lock to mutual exclusion since adding updates is also not thread safe.