### PR TITLE
chore: use newer attribute client with lazy errors

### DIFF
--- a/entity-service-impl/build.gradle.kts
+++ b/entity-service-impl/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
   implementation("org.hypertrace.core.documentstore:document-store:0.5.8")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.4.0")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.4.0")
-  implementation("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.10.4")
+  implementation("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.12.3")
   implementation(project(":entity-type-service-rx-client"))
 
   implementation("com.google.protobuf:protobuf-java-util:3.15.6")


### PR DESCRIPTION
## Description
Use newer attribute client with better performing client (builds errors lazily, less exception filling)