### PR TITLE
fix: change entity client to not return single

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,5 +5,5 @@ ignore:
   SNYK-JAVA-IONETTY-1042268:
     - '*':
         reason: None Given
-        expires: 2021-07-31T00:00:00.000Z
+        expires: 2021-10-31T00:00:00.000Z
 patch: {}

--- a/entity-data-service-rx-client/build.gradle.kts
+++ b/entity-data-service-rx-client/build.gradle.kts
@@ -18,6 +18,9 @@ dependencies {
 
   implementation("org.slf4j:slf4j-api:1.7.30")
   implementation("com.google.guava:guava:30.1.1-jre")
+  implementation("org.slf4j:slf4j-api:1.7.30")
+  annotationProcessor("org.projectlombok:lombok:1.18.18")
+  compileOnly("org.projectlombok:lombok:1.18.18")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")

--- a/entity-data-service-rx-client/src/main/java/org/hypertrace/entity/data/service/rxclient/EntityDataCachingClient.java
+++ b/entity-data-service-rx-client/src/main/java/org/hypertrace/entity/data/service/rxclient/EntityDataCachingClient.java
@@ -12,6 +12,7 @@ import io.grpc.Channel;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.internal.functions.Functions;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -124,8 +125,8 @@ class EntityDataCachingClient implements EntityDataClient {
       }
       EntityDataCachingClient.this
           .createOrUpdateEntity(entityKey, condition)
-          .doOnError(error -> log.error("Error upserting entity", error))
-          .blockingSubscribe();
+          .blockingSubscribe(
+              Functions.emptyConsumer(), error -> log.error("Error upserting entity", error));
     }
 
     private void addNewUpdate(

--- a/entity-data-service-rx-client/src/main/java/org/hypertrace/entity/data/service/rxclient/EntityKey.java
+++ b/entity-data-service-rx-client/src/main/java/org/hypertrace/entity/data/service/rxclient/EntityKey.java
@@ -17,10 +17,6 @@ class EntityKey {
 
   private static final String DEFAULT_TENANT_ID = "default";
 
-  static EntityKey entityInCurrentContext(Entity inputEntity) {
-    return new EntityKey(requireNonNull(RequestContext.CURRENT.get()), requireNonNull(inputEntity));
-  }
-
   private final Entity inputEntity;
   private final String tenantId;
   private final GrpcRxExecutionContext executionContext;
@@ -32,7 +28,7 @@ class EntityKey {
                       ? entity.getIdentifyingAttributesMap()
                       : entity.getEntityId());
 
-  protected EntityKey(@Nonnull RequestContext requestContext, @Nonnull Entity inputEntity) {
+  EntityKey(@Nonnull RequestContext requestContext, @Nonnull Entity inputEntity) {
     requireNonNull(inputEntity.getEntityId());
     requireNonNull(inputEntity.getEntityType());
     this.executionContext = GrpcRxExecutionContext.forContext(requestContext);

--- a/entity-data-service-rx-client/src/test/java/org/hypertrace/entity/data/service/rxclient/EntityDataCachingClientTest.java
+++ b/entity-data-service-rx-client/src/test/java/org/hypertrace/entity/data/service/rxclient/EntityDataCachingClientTest.java
@@ -1,27 +1,19 @@
 package org.hypertrace.entity.data.service.rxclient;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import io.grpc.Context;
 import io.grpc.ManagedChannel;
 import io.grpc.Server;
-import io.grpc.StatusRuntimeException;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.stub.StreamObserver;
-import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.schedulers.TestScheduler;
 import java.io.IOException;
@@ -61,7 +53,6 @@ class EntityDataCachingClientTest {
 
   Server grpcServer;
   ManagedChannel grpcChannel;
-  Context grpcTestContext;
   List<Entity> possibleResponseEntities;
   Optional<Throwable> responseError;
   TestScheduler testScheduler;
@@ -78,7 +69,6 @@ class EntityDataCachingClientTest {
     this.grpcChannel = InProcessChannelBuilder.forName(uniqueName).directExecutor().build();
     this.dataClient = EntityDataClient.builder(this.grpcChannel).build();
     when(this.mockContext.getTenantId()).thenReturn(Optional.of("default tenant"));
-    this.grpcTestContext = Context.current().withValue(RequestContext.CURRENT, this.mockContext);
     this.possibleResponseEntities = List.of(this.defaultResponseEntity);
     this.responseError = Optional.empty();
     doAnswer(
@@ -119,107 +109,13 @@ class EntityDataCachingClientTest {
   }
 
   @Test
-  void cachesConsecutiveCallsForSameEntity() throws Exception {
-    Entity inputEntity = this.defaultResponseEntity.toBuilder().clearEntityName().build();
+  void createOrUpdateCallsUpsert() {
     assertSame(
         this.defaultResponseEntity,
-        this.grpcTestContext.call(
-            () -> this.dataClient.getOrCreateEntity(inputEntity).blockingGet()));
-
-    verify(this.mockDataService, times(1)).mergeAndUpsertEntity(any(), any());
-    verifyNoMoreInteractions(this.mockDataService);
-    assertSame(
-        this.defaultResponseEntity,
-        this.grpcTestContext.call(
-            () -> this.dataClient.getOrCreateEntity(inputEntity).blockingGet()));
-  }
-
-  @Test
-  void supportsMultipleConcurrentCacheKeys() throws Exception {
-    Entity inputEntity = this.defaultResponseEntity.toBuilder().clearEntityName().build();
-    Entity defaultRetrieved =
-        this.grpcTestContext.call(
-            () -> this.dataClient.getOrCreateEntity(inputEntity).blockingGet());
-    assertSame(this.defaultResponseEntity, defaultRetrieved);
-    verify(this.mockDataService, times(1)).mergeAndUpsertEntity(any(), any());
-
-    RequestContext otherMockContext = mock(RequestContext.class);
-    when(otherMockContext.getTenantId()).thenReturn(Optional.of("other tenant"));
-    Context otherGrpcContext =
-        Context.current().withValue(RequestContext.CURRENT, otherMockContext);
-    Entity otherEntityResponse =
-        this.defaultResponseEntity.toBuilder().setEntityName("name-2").build();
-
-    this.possibleResponseEntities = List.of(otherEntityResponse);
-
-    Entity otherRetrieved =
-        otherGrpcContext.call(() -> this.dataClient.getOrCreateEntity(inputEntity).blockingGet());
-    assertSame(otherEntityResponse, otherRetrieved);
-    assertNotSame(defaultRetrieved, otherRetrieved);
-    verify(this.mockDataService, times(2)).mergeAndUpsertEntity(any(), any());
-    verifyNoMoreInteractions(this.mockDataService);
-
-    assertSame(
-        defaultRetrieved,
-        this.grpcTestContext.call(
-            () -> this.dataClient.getOrCreateEntity(inputEntity).blockingGet()));
-
-    assertSame(
-        otherRetrieved,
-        otherGrpcContext.call(() -> this.dataClient.getOrCreateEntity(inputEntity).blockingGet()));
-  }
-
-  @Test
-  void retriesOnError() throws Exception {
-    Entity inputEntity = this.defaultResponseEntity.toBuilder().clearEntityName().build();
-    this.responseError = Optional.of(new UnsupportedOperationException());
-
-    assertThrows(
-        StatusRuntimeException.class,
-        () ->
-            this.grpcTestContext.call(
-                () -> this.dataClient.getOrCreateEntity(inputEntity).blockingGet()));
-    verify(this.mockDataService, times(1)).mergeAndUpsertEntity(any(), any());
-
-    this.responseError = Optional.empty();
-    assertSame(
-        this.defaultResponseEntity,
-        this.grpcTestContext.call(
-            () -> this.dataClient.getOrCreateEntity(inputEntity).blockingGet()));
-    verify(this.mockDataService, times(2)).mergeAndUpsertEntity(any(), any());
-  }
-
-  @Test
-  void hasConfigurableCacheSize() throws Exception {
-    this.dataClient =
-        EntityDataClient.builder(this.grpcChannel).withMaximumCacheContexts(1).build();
-
-    RequestContext otherMockContext = mock(RequestContext.class);
-    when(otherMockContext.getTenantId()).thenReturn(Optional.of("other tenant"));
-    this.grpcTestContext.call(
-        () -> this.dataClient.getOrCreateEntity(this.defaultResponseEntity).blockingGet());
-
-    // This call should evict the original call
-    Context.current()
-        .withValue(RequestContext.CURRENT, otherMockContext)
-        .call(() -> this.dataClient.getOrCreateEntity(this.defaultResponseEntity).blockingGet());
-
-    // Rerunning this call now fire again, a third server call
-    this.grpcTestContext.call(
-        () -> this.dataClient.getOrCreateEntity(this.defaultResponseEntity).blockingGet());
-    verify(this.mockDataService, times(3)).mergeAndUpsertEntity(any(), any());
-  }
-
-  @Test
-  void createOrUpdateCallsUpsert() throws Exception {
-    assertSame(
-        this.defaultResponseEntity,
-        this.grpcTestContext.call(
-            () ->
-                this.dataClient
-                    .createOrUpdateEntity(
-                        this.defaultResponseEntity, UpsertCondition.getDefaultInstance())
-                    .blockingGet()));
+        this.dataClient
+            .createOrUpdateEntity(
+                mockContext, this.defaultResponseEntity, UpsertCondition.getDefaultInstance())
+            .blockingGet());
 
     verify(this.mockDataService, times(1))
         .mergeAndUpsertEntity(
@@ -232,46 +128,30 @@ class EntityDataCachingClientTest {
   }
 
   @Test
-  void createOrUpdateEventuallyThrottlesAndUsesLastProvidedValue() throws Exception {
-    TestObserver<Entity> firstObserver = new TestObserver<>();
-    TestObserver<Entity> secondObserver = new TestObserver<>();
-    TestObserver<Entity> thirdObserver = new TestObserver<>();
+  void createOrUpdateEventuallyThrottlesAndUsesLastProvidedValue() {
     this.possibleResponseEntities = Collections.emptyList(); // Just reflect entities in this test
     Entity firstEntity = this.defaultResponseEntity.toBuilder().setEntityName("first name").build();
     Entity secondEntity =
         this.defaultResponseEntity.toBuilder().setEntityName("second name").build();
     Entity thirdEntity = this.defaultResponseEntity.toBuilder().setEntityName("third name").build();
-    this.grpcTestContext.run(
-        () ->
-            this.dataClient
-                .createOrUpdateEntityEventually(
-                    firstEntity, UpsertCondition.getDefaultInstance(), Duration.ofMillis(1000))
-                .subscribe(firstObserver));
+
+    this.dataClient.createOrUpdateEntityEventually(
+        mockContext, firstEntity, UpsertCondition.getDefaultInstance(), Duration.ofMillis(1000));
 
     testScheduler.advanceTimeBy(300, TimeUnit.MILLISECONDS);
-    this.grpcTestContext.run(
-        () ->
-            this.dataClient
-                .createOrUpdateEntityEventually(
-                    secondEntity, UpsertCondition.getDefaultInstance(), Duration.ofMillis(200))
-                .subscribe(secondObserver));
+
+    this.dataClient.createOrUpdateEntityEventually(
+        mockContext, secondEntity, UpsertCondition.getDefaultInstance(), Duration.ofMillis(200));
 
     testScheduler.advanceTimeBy(150, TimeUnit.MILLISECONDS);
 
-    this.grpcTestContext.run(
-        () ->
-            this.dataClient
-                .createOrUpdateEntityEventually(
-                    thirdEntity, UpsertCondition.getDefaultInstance(), Duration.ofMillis(5000))
-                .subscribe(thirdObserver));
+    this.dataClient.createOrUpdateEntityEventually(
+        mockContext, thirdEntity, UpsertCondition.getDefaultInstance(), Duration.ofMillis(5000));
 
     testScheduler.advanceTimeBy(49, TimeUnit.MILLISECONDS);
 
     // All 3 should complete at 500ms (we're currently at 499ms)
     verifyNoInteractions(this.mockDataService);
-    firstObserver.assertNotComplete().assertNoErrors().assertNoValues();
-    secondObserver.assertNotComplete().assertNoErrors().assertNoValues();
-    thirdObserver.assertNotComplete().assertNoErrors().assertNoValues();
 
     testScheduler.advanceTimeBy(1, TimeUnit.MILLISECONDS);
 
@@ -283,17 +163,5 @@ class EntityDataCachingClientTest {
                     .setUpsertCondition(UpsertCondition.getDefaultInstance())
                     .build()),
             any());
-
-    firstObserver.assertResult(thirdEntity);
-    secondObserver.assertResult(thirdEntity);
-    thirdObserver.assertResult(thirdEntity);
-
-    // Result should be in cache now, let's try to fetch and verify no server call
-    Entity fetchedEntity =
-        this.grpcTestContext.call(
-            () -> this.dataClient.getOrCreateEntity(firstEntity).blockingGet());
-
-    assertEquals(thirdEntity, fetchedEntity);
-    verifyNoMoreInteractions(this.mockDataService);
   }
 }


### PR DESCRIPTION
## Description
The motivation here is that the previous client API had major performance issues. Given the purpose of this api, high traffic writes, reducing to a simpler API makes sense for the safe of perf.

There were two major issues previously:
1. Each call returned a single, which requires a new subscription for each invocation. The subscriptions aren't _too_ heavy, but that's still a lot of unnecessary churn considering we don't actually read the result anywhere today.
2. By creating a subscription, the entire observable pipeline, including its lambda captures are retained in memory until the subscription is resolved (by default, 15s). This means that we're always holding 15s of ingestion data for no good reason. This needs to be fixed on the caller side, since the client can't control the context it's called in.

This was done as a breaking change, since these only currently have one consumer (enrichment) and that consumer needs to migrate.

### Testing
Updated UTs, compiled and tested full system locally.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

