### PR TITLE
Changes to perform bulk operation on attribute with array value

### DIFF
--- a/entity-service-api/src/main/proto/org/hypertrace/entity/query/service/v1/entity_query_request.proto
+++ b/entity-service-api/src/main/proto/org/hypertrace/entity/query/service/v1/entity_query_request.proto
@@ -50,3 +50,18 @@ message SetAttribute {
   ColumnIdentifier attribute = 1;
   LiteralConstant value = 2;
 }
+
+message BulkEntityArrayAttributeUpdateRequest {
+  string entityType = 1;
+  repeated string entityIds = 2;
+  ColumnIdentifier attribute = 3;
+  Operation operation = 4;
+  repeated LiteralConstant values = 5;
+
+  enum Operation {
+    OPERATION_UNSPECIFIED = 0;
+    OPERATION_ADD = 1;
+    OPERATION_REMOVE = 2;
+    OPERATION_SET = 3;
+  }
+}

--- a/entity-service-api/src/main/proto/org/hypertrace/entity/query/service/v1/entity_query_request.proto
+++ b/entity-service-api/src/main/proto/org/hypertrace/entity/query/service/v1/entity_query_request.proto
@@ -52,8 +52,8 @@ message SetAttribute {
 }
 
 message BulkEntityArrayAttributeUpdateRequest {
-  string entityType = 1;
-  repeated string entityIds = 2;
+  string entity_type = 1;
+  repeated string entity_ids = 2;
   ColumnIdentifier attribute = 3;
   Operation operation = 4;
   repeated LiteralConstant values = 5;
@@ -64,4 +64,7 @@ message BulkEntityArrayAttributeUpdateRequest {
     OPERATION_REMOVE = 2;
     OPERATION_SET = 3;
   }
+}
+
+message BulkEntityArrayAttributeUpdateResponse {
 }

--- a/entity-service-api/src/main/proto/org/hypertrace/entity/query/service/v1/entity_query_service.proto
+++ b/entity-service-api/src/main/proto/org/hypertrace/entity/query/service/v1/entity_query_service.proto
@@ -18,6 +18,6 @@ service EntityQueryService {
   }
   rpc total (TotalEntitiesRequest) returns (TotalEntitiesResponse) {
   }
-  rpc bulkUpdateEntityArrayAttribute (BulkEntityArrayAttributeUpdateRequest) returns (stream ResultSetChunk) {
+  rpc bulkUpdateEntityArrayAttribute (BulkEntityArrayAttributeUpdateRequest) returns (BulkEntityArrayAttributeUpdateResponse) {
   }
 }

--- a/entity-service-api/src/main/proto/org/hypertrace/entity/query/service/v1/entity_query_service.proto
+++ b/entity-service-api/src/main/proto/org/hypertrace/entity/query/service/v1/entity_query_service.proto
@@ -18,4 +18,6 @@ service EntityQueryService {
   }
   rpc total (TotalEntitiesRequest) returns (TotalEntitiesResponse) {
   }
+  rpc bulkUpdateEntityArrayAttribute (BulkEntityArrayAttributeUpdateRequest) returns (stream ResultSetChunk) {
+  }
 }

--- a/entity-service-impl/build.gradle.kts
+++ b/entity-service-impl/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
   annotationProcessor("org.projectlombok:lombok:1.18.18")
   compileOnly("org.projectlombok:lombok:1.18.18")
 
-  implementation("org.hypertrace.core.documentstore:document-store:0.6.0")
+  implementation("org.hypertrace.core.documentstore:document-store:0.6.1")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.6.1")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.6.1")
   implementation("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.12.3")

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryServiceImpl.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryServiceImpl.java
@@ -1,6 +1,9 @@
 package org.hypertrace.entity.query.service;
 
 import static java.util.Objects.isNull;
+import static java.util.stream.Collectors.joining;
+import static org.hypertrace.entity.data.service.v1.AttributeValue.VALUE_LIST_FIELD_NUMBER;
+import static org.hypertrace.entity.data.service.v1.AttributeValueList.VALUES_FIELD_NUMBER;
 import static org.hypertrace.entity.query.service.EntityAttributeMapping.ENTITY_ATTRIBUTE_DOC_PREFIX;
 import static org.hypertrace.entity.service.constants.EntityCollectionConstants.RAW_ENTITIES_COLLECTION;
 
@@ -18,6 +21,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import org.hypertrace.core.documentstore.BulkArrayValueUpdateRequest;
 import org.hypertrace.core.documentstore.Collection;
@@ -30,6 +34,7 @@ import org.hypertrace.core.grpcutils.client.GrpcChannelRegistry;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.entity.data.service.DocumentParser;
 import org.hypertrace.entity.data.service.v1.AttributeValue;
+import org.hypertrace.entity.data.service.v1.AttributeValueList;
 import org.hypertrace.entity.data.service.v1.Entity;
 import org.hypertrace.entity.data.service.v1.Query;
 import org.hypertrace.entity.query.service.v1.BulkEntityArrayAttributeUpdateRequest;
@@ -70,7 +75,16 @@ public class EntityQueryServiceImpl extends EntityQueryServiceImplBase {
   private static final DocumentParser DOCUMENT_PARSER = new DocumentParser();
   private static final String CHUNK_SIZE_CONFIG = "entity.query.service.response.chunk.size";
   private static final int DEFAULT_CHUNK_SIZE = 10_000;
-  private static final String ARRAY_VALUE_PATH_SUFFIX = ".valueList.values";
+  private static final String ARRAY_VALUE_PATH_SUFFIX =
+      Stream.of(
+              "",
+              AttributeValue.getDescriptor()
+                  .findFieldByNumber(VALUE_LIST_FIELD_NUMBER)
+                  .getJsonName(),
+              AttributeValueList.getDescriptor()
+                  .findFieldByNumber(VALUES_FIELD_NUMBER)
+                  .getJsonName())
+          .collect(joining("."));
 
   private final Collection entitiesCollection;
   private final EntityQueryConverter entityQueryConverter;

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryServiceImpl.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryServiceImpl.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -365,7 +366,7 @@ public class EntityQueryServiceImpl extends EntityQueryServiceImplBase {
       Set<Key> keys =
           request.getEntityIdsList().stream()
               .map(entityId -> new SingleValueKey(tenantId, entityId))
-              .collect(Collectors.toSet());
+              .collect(Collectors.toCollection(LinkedHashSet::new));
 
       String attributeId = request.getAttribute().getColumnName();
 

--- a/entity-service/build.gradle.kts
+++ b/entity-service/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
   implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.6.1")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.6.1")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.28")
-  implementation("org.hypertrace.core.documentstore:document-store:0.6.0")
+  implementation("org.hypertrace.core.documentstore:document-store:0.6.1")
 
   runtimeOnly("io.grpc:grpc-netty:1.40.1")
   constraints {


### PR DESCRIPTION
1. Exposing it in EntityQueryService as other required helper classes and method exists in that class. Don't like it. However exposing it in EntityDataService will require some major code refactoring.
2. Hard-coded suffix for array value to ".valueList.values".  Suggestions are welcome.