### PR TITLE
ci: fix codecov and snyk

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -90,6 +90,6 @@ jobs:
       - name: Setup snyk
         uses: snyk/actions/setup@0.3.0
       - name: Snyk test
-        run: snyk test --all-sub-projects --org=hypertrace --severity-threshold=low --policy-path=.snyk --configuration-matching='^runtimeClasspath$'
+        run: snyk test --all-sub-projects --org=hypertrace --severity-threshold=low --policy-path=.snyk --configuration-matching='^runtimeClasspath$' --remote-repo-url='${{ github.server_url }}/${{ github.repository }}.git'
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -34,10 +34,9 @@ jobs:
           args: jacocoTestReport
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           name: unit test reports
-          fail_ci_if_error: true
           flags: unit
 
       - name: Integration test
@@ -46,10 +45,9 @@ jobs:
           args: jacocoIntegrationTestReport
   
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           name: integration test reports
-          fail_ci_if_error: true
           flags: integration
   
       - name: copy test reports


### PR DESCRIPTION
## Description
Two separate fixes here.
Codecov: bash uploader is being deprecated and is currently in the brownout phase. We need to upgrade to the v2 gh action in all repos.

More info: https://about.codecov.io/blog/codecov-uploader-deprecation-plan/

Snyk: Snyk changed their server implementation, and the default remote uri detection no longer works. After weeks with snyk support, they made some changes and now this works, we need to add this param for all invocations.