### PR TITLE
fix: map api service name

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,5 +5,5 @@ ignore:
   SNYK-JAVA-IONETTY-1042268:
     - '*':
         reason: None Given
-        expires: 2021-10-31T00:00:00.000Z
+        expires: 2022-03-31T00:00:00.000Z
 patch: {}

--- a/entity-data-service-rx-client/build.gradle.kts
+++ b/entity-data-service-rx-client/build.gradle.kts
@@ -13,8 +13,8 @@ dependencies {
   api(project(":entity-service-api"))
   api("io.reactivex.rxjava3:rxjava:3.0.11")
 
-  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.6.1")
-  implementation("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.6.1")
+  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.6.2")
+  implementation("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.6.2")
 
   implementation("org.slf4j:slf4j-api:1.7.30")
   implementation("com.google.guava:guava:30.1.1-jre")
@@ -25,6 +25,6 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")
   testImplementation("org.mockito:mockito-junit-jupiter:3.8.0")
-  testImplementation("io.grpc:grpc-core:1.40.1")
+  testImplementation("io.grpc:grpc-core:1.42.0")
   testRuntimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.14.1")
 }

--- a/entity-service-api/build.gradle.kts
+++ b/entity-service-api/build.gradle.kts
@@ -22,7 +22,7 @@ protobuf {
     // the identifier, which can be referred to in the "plugins"
     // container of the "generateProtoTasks" closure.
     id("grpc_java") {
-      artifact = "io.grpc:protoc-gen-grpc-java:1.40.1"
+      artifact = "io.grpc:protoc-gen-grpc-java:1.42.0"
     }
 
     if (generateLocalGoGrpcFiles) {
@@ -61,7 +61,7 @@ sourceSets {
 }
 
 dependencies {
-  api("io.grpc:grpc-protobuf:1.40.1")
-  api("io.grpc:grpc-stub:1.40.1")
+  api("io.grpc:grpc-protobuf:1.42.0")
+  api("io.grpc:grpc-stub:1.42.0")
   api("javax.annotation:javax.annotation-api:1.3.2")
 }

--- a/entity-service-change-event-api/build.gradle.kts
+++ b/entity-service-change-event-api/build.gradle.kts
@@ -22,6 +22,6 @@ sourceSets {
 }
 
 dependencies {
-  api("com.google.protobuf:protobuf-java:3.18.0")
+  api("com.google.protobuf:protobuf-java:3.19.1")
   api(project(":entity-service-api"))
 }

--- a/entity-service-change-event-generator/build.gradle.kts
+++ b/entity-service-change-event-generator/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
   api("com.typesafe:config:1.4.1")
 
   implementation("org.hypertrace.core.eventstore:event-store:0.1.2")
-  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.6.1")
+  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.6.2")
   implementation("com.google.guava:guava:30.1.1-jre")
   implementation("org.slf4j:slf4j-api:1.7.30")
 

--- a/entity-service-client/build.gradle.kts
+++ b/entity-service-client/build.gradle.kts
@@ -13,11 +13,11 @@ dependencies {
   api(project(":entity-service-api"))
   api("com.typesafe:config:1.4.1")
 
-  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.6.1")
+  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.6.2")
   implementation("org.slf4j:slf4j-api:1.7.30")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.28")
 
-  testImplementation("io.grpc:grpc-core:1.40.1")
+  testImplementation("io.grpc:grpc-core:1.42.0")
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")
   testImplementation("org.mockito:mockito-junit-jupiter:3.8.0")

--- a/entity-service-impl/build.gradle.kts
+++ b/entity-service-impl/build.gradle.kts
@@ -11,14 +11,14 @@ dependencies {
   annotationProcessor("org.projectlombok:lombok:1.18.18")
   compileOnly("org.projectlombok:lombok:1.18.18")
 
-  implementation("org.hypertrace.core.documentstore:document-store:0.6.1")
-  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.6.1")
-  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.6.1")
+  implementation("org.hypertrace.core.documentstore:document-store:0.6.2")
+  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.6.2")
+  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.6.2")
   implementation("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.12.3")
   implementation(project(":entity-type-service-rx-client"))
   implementation(project(":entity-service-change-event-generator"))
 
-  implementation("com.google.protobuf:protobuf-java-util:3.15.6")
+  implementation("com.google.protobuf:protobuf-java-util:3.19.1")
   implementation("com.github.f4b6a3:uuid-creator:3.5.0")
   implementation("io.reactivex.rxjava3:rxjava:3.0.11")
   implementation("com.google.guava:guava:30.1.1-jre")

--- a/entity-service/build.gradle.kts
+++ b/entity-service/build.gradle.kts
@@ -16,12 +16,12 @@ dependencies {
   implementation(project(":entity-service-impl"))
   implementation(project(":entity-service-change-event-generator"))
 
-  implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.6.1")
-  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.6.1")
+  implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.6.2")
+  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.6.2")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.28")
-  implementation("org.hypertrace.core.documentstore:document-store:0.6.1")
+  implementation("org.hypertrace.core.documentstore:document-store:0.6.2")
 
-  runtimeOnly("io.grpc:grpc-netty:1.40.1")
+  runtimeOnly("io.grpc:grpc-netty:1.42.0")
   constraints {
     runtimeOnly("io.netty:netty-codec-http2:4.1.68.Final") {
       because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1089809")
@@ -43,7 +43,7 @@ dependencies {
   integrationTestImplementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.4.0")
   integrationTestImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   integrationTestImplementation("org.hypertrace.core.serviceframework:integrationtest-service-framework:0.1.28")
-  integrationTestImplementation("org.testcontainers:testcontainers:1.15.2")
+  integrationTestImplementation("org.testcontainers:testcontainers:1.16.1")
   integrationTestImplementation("com.github.stefanbirkner:system-lambda:1.2.0")
 }
 

--- a/entity-service/src/main/resources/configs/common/application.conf
+++ b/entity-service/src/main/resources/configs/common/application.conf
@@ -62,6 +62,11 @@ entity.service.attributeMap = [
     "subDocPath": "attributes.api_discovery_state"
   },
   {
+    "scope": "API",
+    "name": "API.serviceName",
+    "subDocPath": "attributes.SERVICE_NAME"
+  },
+  {
     "scope": "SERVICE",
     "name": "SERVICE.id",
     "subDocPath": "entityId"

--- a/entity-type-service-rx-client/build.gradle.kts
+++ b/entity-type-service-rx-client/build.gradle.kts
@@ -13,8 +13,8 @@ dependencies {
   api(project(":entity-service-api"))
   api("io.reactivex.rxjava3:rxjava:3.0.11")
 
-  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.4.0")
-  implementation("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.4.0")
+  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.6.2")
+  implementation("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.6.2")
 
   implementation("org.slf4j:slf4j-api:1.7.30")
   implementation("com.google.guava:guava:30.1.1-jre")
@@ -22,6 +22,6 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")
   testImplementation("org.mockito:mockito-junit-jupiter:3.8.0")
-  testImplementation("io.grpc:grpc-core:1.36.1")
+  testImplementation("io.grpc:grpc-core:1.42.0")
   testRuntimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.14.1")
 }


### PR DESCRIPTION
## Description
This is the second half of fix for https://github.com/hypertrace/hypertrace-ui/issues/1061 . In that ticket, previously @skjindal93 started populating serviceName on API entities but instead of using the new attributeId which would be mapped automatically, it used the old entity service key which requires an explicit subpath mapping. This PR adds that mapping.

### Testing
Built and ran locally, verified behavior.

Closes https://github.com/hypertrace/hypertrace-ui/issues/1061
