### PR TITLE
Add integration test for filtering on composite values (arrays and maps)

### DIFF
--- a/entity-service-api/build.gradle.kts
+++ b/entity-service-api/build.gradle.kts
@@ -61,7 +61,7 @@ sourceSets {
 }
 
 dependencies {
-  api("io.grpc:grpc-protobuf:1.43.1")
-  api("io.grpc:grpc-stub:1.43.1")
+  api("io.grpc:grpc-protobuf:1.43.2")
+  api("io.grpc:grpc-stub:1.43.2")
   api("javax.annotation:javax.annotation-api:1.3.2")
 }

--- a/entity-service-client/build.gradle.kts
+++ b/entity-service-client/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
   implementation("org.slf4j:slf4j-api:1.7.30")
   implementation("org.hypertrace.core.serviceframework:platform-metrics:0.1.28")
 
-  testImplementation("io.grpc:grpc-core:1.43.1")
+  testImplementation("io.grpc:grpc-core:1.43.2")
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")
   testImplementation("org.mockito:mockito-junit-jupiter:3.8.0")

--- a/entity-service-impl/build.gradle.kts
+++ b/entity-service-impl/build.gradle.kts
@@ -8,17 +8,17 @@ dependencies {
   api(project(":entity-service-api"))
   api("org.hypertrace.core.serviceframework:service-framework-spi:0.1.28")
 
-  annotationProcessor("org.projectlombok:lombok:1.18.18")
+  annotationProcessor("org.projectlombok:lombok:1.18.22")
   compileOnly("org.projectlombok:lombok:1.18.18")
 
-  implementation("org.hypertrace.core.documentstore:document-store:0.6.4")
+  implementation("org.hypertrace.core.documentstore:document-store:0.6.5")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.7.0")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.7.0")
   implementation("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.12.3")
   implementation(project(":entity-type-service-rx-client"))
   implementation(project(":entity-service-change-event-generator"))
 
-  implementation("com.google.protobuf:protobuf-java-util:3.19.1")
+  implementation("com.google.protobuf:protobuf-java-util:3.19.3")
   implementation("com.github.f4b6a3:uuid-creator:3.5.0")
   implementation("io.reactivex.rxjava3:rxjava:3.0.11")
   implementation("com.google.guava:guava:30.1.1-jre")

--- a/entity-service/build.gradle.kts
+++ b/entity-service/build.gradle.kts
@@ -76,16 +76,6 @@ tasks.integrationTest {
   finalizedBy("stopAttributeServiceContainer")
 }
 
-tasks.register<DockerStartContainer>("startContainers") {
-  dependsOn("startMongoContainer")
-  dependsOn("startAttributeServiceContainer")
-//  targetContainerId(tasks.getByName<DockerCreateContainer>("createAttributeServiceContainer").containerId)
-}
-
-tasks.register<DockerStopContainer>("stopContainers") {
-  finalizedBy("stopMongoContainer", "stopAttributeServiceContainer")
-}
-
 tasks.register<DockerStartContainer>("startMongoContainer") {
   dependsOn("createMongoContainer")
   targetContainerId(tasks.getByName<DockerCreateContainer>("createMongoContainer").containerId)

--- a/entity-service/build.gradle.kts
+++ b/entity-service/build.gradle.kts
@@ -1,3 +1,10 @@
+import com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer
+import com.bmuschko.gradle.docker.tasks.container.DockerStartContainer
+import com.bmuschko.gradle.docker.tasks.container.DockerStopContainer
+import com.bmuschko.gradle.docker.tasks.image.DockerPullImage
+import com.bmuschko.gradle.docker.tasks.network.DockerCreateNetwork
+import com.bmuschko.gradle.docker.tasks.network.DockerRemoveNetwork
+
 plugins {
   java
   application
@@ -19,7 +26,7 @@ dependencies {
   implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.7.0")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.7.0")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.28")
-  implementation("org.hypertrace.core.documentstore:document-store:0.6.4")
+  implementation("org.hypertrace.core.documentstore:document-store:0.6.5")
 
   runtimeOnly("io.grpc:grpc-netty:1.43.1")
 
@@ -37,6 +44,8 @@ dependencies {
   integrationTestImplementation("org.hypertrace.core.serviceframework:integrationtest-service-framework:0.1.28")
   integrationTestImplementation("org.testcontainers:testcontainers:1.16.1")
   integrationTestImplementation("com.github.stefanbirkner:system-lambda:1.2.0")
+  integrationTestImplementation("org.hypertrace.core.attribute.service:attribute-service-api:0.13.6")
+  integrationTestImplementation("org.hypertrace.core.attribute.service:attribute-service-client:0.12.5")
 }
 
 application {
@@ -59,4 +68,83 @@ hypertraceDocker {
       port.set(50061)
     }
   }
+}
+
+tasks.integrationTest {
+  useJUnitPlatform()
+  dependsOn("startAttributeServiceContainer")
+  finalizedBy("stopAttributeServiceContainer")
+}
+
+tasks.register<DockerStartContainer>("startContainers") {
+  dependsOn("startMongoContainer")
+  dependsOn("startAttributeServiceContainer")
+//  targetContainerId(tasks.getByName<DockerCreateContainer>("createAttributeServiceContainer").containerId)
+}
+
+tasks.register<DockerStopContainer>("stopContainers") {
+  finalizedBy("stopMongoContainer", "stopAttributeServiceContainer")
+}
+
+tasks.register<DockerStartContainer>("startMongoContainer") {
+  dependsOn("createMongoContainer")
+  targetContainerId(tasks.getByName<DockerCreateContainer>("createMongoContainer").containerId)
+}
+
+tasks.register<DockerCreateContainer>("createMongoContainer") {
+  dependsOn("createIntegrationTestNetwork")
+  dependsOn("pullMongoImage")
+  targetImageId(tasks.getByName<DockerPullImage>("pullMongoImage").image)
+  containerName.set("mongo-local")
+  hostConfig.network.set(tasks.getByName<DockerCreateNetwork>("createIntegrationTestNetwork").networkId)
+  hostConfig.portBindings.set(listOf("37017:27017"))
+  hostConfig.autoRemove.set(true)
+}
+
+tasks.register<DockerPullImage>("pullMongoImage") {
+  image.set("mongo:4.4.0")
+}
+
+tasks.register<DockerStopContainer>("stopMongoContainer") {
+  targetContainerId(tasks.getByName<DockerCreateContainer>("createMongoContainer").containerId)
+  finalizedBy("removeIntegrationTestNetwork")
+}
+
+tasks.register<DockerCreateNetwork>("createIntegrationTestNetwork") {
+  networkId.set("entity-svc-int-test")
+  networkName.set("entity-svc-int-test")
+}
+
+tasks.register<DockerRemoveNetwork>("removeIntegrationTestNetwork") {
+  networkId.set("entity-svc-int-test")
+}
+
+tasks.register<DockerStartContainer>("startAttributeServiceContainer") {
+  dependsOn("startMongoContainer")
+  dependsOn("createAttributeServiceContainer")
+  targetContainerId(tasks.getByName<DockerCreateContainer>("createAttributeServiceContainer").containerId)
+}
+
+tasks.register<DockerCreateContainer>("createAttributeServiceContainer") {
+  dependsOn("pullAttributeServiceImage")
+  targetImageId(tasks.getByName<DockerPullImage>("pullAttributeServiceImage").image)
+  containerName.set("attribute-service-local")
+  envVars.put("SERVICE_NAME", "attribute-service")
+  envVars.put("mongo_host", tasks.getByName<DockerCreateContainer>("createMongoContainer").containerName)
+  envVars.put("BOOTSTRAP_CONFIG_URI", "file:///app/resources/configs")
+  envVars.put("CLUSTER_NAME", "test")
+  exposePorts("tcp", listOf(9012))
+  hostConfig.portBindings.set(listOf("9112:9012"))
+  hostConfig.binds.put("$projectDir/src/integrationTest/resources/configs/attribute-service/application.conf", "/app/resources/configs/attribute-service/test/application.conf")
+  hostConfig.network.set(tasks.getByName<DockerCreateNetwork>("createIntegrationTestNetwork").networkId)
+  hostConfig.autoRemove.set(true)
+}
+
+tasks.register<DockerPullImage>("pullAttributeServiceImage") {
+  image.set("hypertrace/attribute-service:0.13.5")
+}
+
+tasks.register<DockerStopContainer>("stopAttributeServiceContainer") {
+  targetContainerId(tasks.getByName<DockerCreateContainer>("createAttributeServiceContainer").containerId)
+  finalizedBy("stopMongoContainer")
 }

--- a/entity-service/src/integrationTest/java/org/hypertrace/entity/service/client/config/EntityServiceTestConfig.java
+++ b/entity-service/src/integrationTest/java/org/hypertrace/entity/service/client/config/EntityServiceTestConfig.java
@@ -10,8 +10,7 @@ import org.hypertrace.core.serviceframework.config.IntegrationTestConfigClientFa
 public class EntityServiceTestConfig {
 
   public static EntityServiceClientConfig getClientConfig() {
-    Config serviceConfig =
-        IntegrationTestConfigClientFactory.getConfigClientForService("entity-service").getConfig();
+    Config serviceConfig = getServiceConfig();
     Map<String, Object> entityServiceClientConfigMap = new HashMap<>();
     Map<String, Object> map = new HashMap<>();
     map.put("host", "localhost");
@@ -19,5 +18,9 @@ public class EntityServiceTestConfig {
     entityServiceClientConfigMap.put("entity.service.config", map);
     Config config = ConfigFactory.parseMap(entityServiceClientConfigMap);
     return EntityServiceClientConfig.from(config);
+  }
+
+  public static Config getServiceConfig() {
+    return IntegrationTestConfigClientFactory.getConfigClientForService("entity-service").getConfig();
   }
 }

--- a/entity-service/src/integrationTest/java/org/hypertrace/entity/service/client/config/EntityServiceTestConfig.java
+++ b/entity-service/src/integrationTest/java/org/hypertrace/entity/service/client/config/EntityServiceTestConfig.java
@@ -21,6 +21,7 @@ public class EntityServiceTestConfig {
   }
 
   public static Config getServiceConfig() {
-    return IntegrationTestConfigClientFactory.getConfigClientForService("entity-service").getConfig();
+    return IntegrationTestConfigClientFactory.getConfigClientForService("entity-service")
+        .getConfig();
   }
 }

--- a/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityDataServiceRelationshipsTest.java
+++ b/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityDataServiceRelationshipsTest.java
@@ -1,7 +1,5 @@
 package org.hypertrace.entity.service.service;
 
-import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
-
 import com.typesafe.config.ConfigFactory;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -26,46 +24,21 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.utility.DockerImageName;
 
 /** Test case for testing relationships CRUD with {@link EntityDataServiceClient} */
 public class EntityDataServiceRelationshipsTest {
 
-  private static final Logger LOG =
-      LoggerFactory.getLogger(EntityDataServiceRelationshipsTest.class);
-  private static final Slf4jLogConsumer logConsumer = new Slf4jLogConsumer(LOG);
-
   private static EntityDataServiceClient entityDataServiceClient;
   private static final String TENANT_ID =
       "__testTenant__" + EntityDataServiceTest.class.getSimpleName();
-  private static final int CONTAINER_STARTUP_ATTEMPTS = 5;
 
-  private static GenericContainer<?> mongo;
   private static ManagedChannel channel;
 
   @BeforeAll
-  public static void setUp() throws Exception {
+  public static void setUp() {
+    ConfigFactory.invalidateCaches();
+    IntegrationTestServerUtil.startServices(new String[] {"entity-service"});
 
-    mongo =
-        new GenericContainer<>(DockerImageName.parse("hypertrace/mongodb:main"))
-            .withExposedPorts(27017)
-            .withStartupAttempts(CONTAINER_STARTUP_ATTEMPTS)
-            .waitingFor(Wait.forListeningPort())
-            .withLogConsumer(logConsumer);
-    mongo.start();
-
-    withEnvironmentVariable("MONGO_HOST", mongo.getHost())
-        .and("MONGO_PORT", mongo.getMappedPort(27017).toString())
-        .execute(
-            () -> {
-              ConfigFactory.invalidateCaches();
-              IntegrationTestServerUtil.startServices(new String[] {"entity-service"});
-            });
     EntityServiceClientConfig entityServiceTestConfig = EntityServiceTestConfig.getClientConfig();
     channel =
         ManagedChannelBuilder.forAddress(
@@ -81,7 +54,6 @@ public class EntityDataServiceRelationshipsTest {
   public static void teardown() {
     channel.shutdown();
     IntegrationTestServerUtil.shutdownServices();
-    mongo.stop();
   }
 
   private static void setupEntityTypes() {

--- a/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityQueryServiceTest.java
+++ b/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityQueryServiceTest.java
@@ -486,7 +486,7 @@ public class EntityQueryServiceTest {
                     .setOperator(Operator.OR)
                     .addChildFilter(
                         Filter.newBuilder()
-                            .setOperator(Operator.EQ)
+                            .setOperator(Operator.IN)
                             .setLhs(
                                 Expression.newBuilder()
                                     .setColumnIdentifier(

--- a/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityQueryServiceTest.java
+++ b/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityQueryServiceTest.java
@@ -132,8 +132,12 @@ public class EntityQueryServiceTest {
                 RequestContextClientCallCredsProviderFactory.getClientCallCredsProvider().get());
     entityDataServiceClient = new EntityDataServiceClient(channel);
 
-    Channel attributeChannel = ManagedChannelBuilder.forAddress(config.getString(
-        ATTRIBUTE_SERVICE_HOST_KEY), config.getInt(ATTRIBUTE_SERVICE_PORT_KEY)).usePlaintext().build();
+    Channel attributeChannel =
+        ManagedChannelBuilder.forAddress(
+                config.getString(ATTRIBUTE_SERVICE_HOST_KEY),
+                config.getInt(ATTRIBUTE_SERVICE_PORT_KEY))
+            .usePlaintext()
+            .build();
 
     setUpAttributes(attributeChannel);
 
@@ -199,33 +203,33 @@ public class EntityQueryServiceTest {
   }
 
   private static void setUpAttributes(Channel channel) {
-    AttributeMetadata labelsAttribute = AttributeMetadata.newBuilder()
-        .setDisplayName("Endpoint labels")
-        .addSources(AttributeSource.EDS)
-        .setFqn(API_LABELS_ATTR)
-        .setGroupable(false)
-        .setId(API_LABELS_ATTR)
-        .setKey("labels")
-        .setScopeString("API")
-        .setValueKind(
-            org.hypertrace.core.attribute.service.v1.AttributeKind.TYPE_STRING_ARRAY)
-        .setScope(AttributeScope.API)
-        .setType(org.hypertrace.core.attribute.service.v1.AttributeType.ATTRIBUTE)
-        .build();
+    AttributeMetadata labelsAttribute =
+        AttributeMetadata.newBuilder()
+            .setDisplayName("Endpoint labels")
+            .addSources(AttributeSource.EDS)
+            .setFqn(API_LABELS_ATTR)
+            .setGroupable(false)
+            .setId(API_LABELS_ATTR)
+            .setKey("labels")
+            .setScopeString("API")
+            .setValueKind(org.hypertrace.core.attribute.service.v1.AttributeKind.TYPE_STRING_ARRAY)
+            .setScope(AttributeScope.API)
+            .setType(org.hypertrace.core.attribute.service.v1.AttributeType.ATTRIBUTE)
+            .build();
 
-    AttributeMetadata httpUrlAttribute = AttributeMetadata.newBuilder()
-        .setDisplayName("HTTP URL object")
-        .addSources(AttributeSource.EDS)
-        .setFqn(API_HTTP_URL_ATTR)
-        .setGroupable(false)
-        .setId(API_HTTP_URL_ATTR)
-        .setKey("http_url")
-        .setScopeString("API")
-        .setValueKind(
-            org.hypertrace.core.attribute.service.v1.AttributeKind.TYPE_STRING_MAP)
-        .setScope(AttributeScope.API)
-        .setType(org.hypertrace.core.attribute.service.v1.AttributeType.ATTRIBUTE)
-        .build();
+    AttributeMetadata httpUrlAttribute =
+        AttributeMetadata.newBuilder()
+            .setDisplayName("HTTP URL object")
+            .addSources(AttributeSource.EDS)
+            .setFqn(API_HTTP_URL_ATTR)
+            .setGroupable(false)
+            .setId(API_HTTP_URL_ATTR)
+            .setKey("http_url")
+            .setScopeString("API")
+            .setValueKind(org.hypertrace.core.attribute.service.v1.AttributeKind.TYPE_STRING_MAP)
+            .setScope(AttributeScope.API)
+            .setType(org.hypertrace.core.attribute.service.v1.AttributeType.ATTRIBUTE)
+            .build();
 
     AttributeCreateRequest request =
         AttributeCreateRequest.newBuilder()
@@ -419,7 +423,8 @@ public class EntityQueryServiceTest {
             .setTenantId(TENANT_ID)
             .setEntityType(EntityType.SERVICE.name())
             .setEntityName("Some Service 2")
-            .putAttributes(apiAttributesMap.get(API_DISCOVERY_STATE_ATTR), createAttribute(filterValue2))
+            .putAttributes(
+                apiAttributesMap.get(API_DISCOVERY_STATE_ATTR), createAttribute(filterValue2))
             .putIdentifyingAttributes(
                 EntityConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_FQN),
                 generateRandomUUIDAttrValue())
@@ -441,7 +446,8 @@ public class EntityQueryServiceTest {
             .setTenantId(TENANT_ID)
             .setEntityType(EntityType.SERVICE.name())
             .setEntityName("Some Service 3")
-            .putAttributes("http_url", AttributeValue.newBuilder().setValueMap(attributeMap).build())
+            .putAttributes(
+                "http_url", AttributeValue.newBuilder().setValueMap(attributeMap).build())
             .putIdentifyingAttributes(
                 EntityConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_FQN),
                 generateRandomUUIDAttrValue())
@@ -469,7 +475,8 @@ public class EntityQueryServiceTest {
             .setTenantId(TENANT_ID)
             .setEntityType(EntityType.SERVICE.name())
             .setEntityName("Some Service 5")
-            .putAttributes(apiAttributesMap.get(API_DISCOVERY_STATE_ATTR), generateRandomUUIDAttrValue())
+            .putAttributes(
+                apiAttributesMap.get(API_DISCOVERY_STATE_ATTR), generateRandomUUIDAttrValue())
             .putIdentifyingAttributes(
                 EntityConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_FQN),
                 generateRandomUUIDAttrValue())
@@ -490,7 +497,8 @@ public class EntityQueryServiceTest {
                             .setLhs(
                                 Expression.newBuilder()
                                     .setColumnIdentifier(
-                                        ColumnIdentifier.newBuilder().setColumnName(API_LABELS_ATTR)))
+                                        ColumnIdentifier.newBuilder()
+                                            .setColumnName(API_LABELS_ATTR)))
                             .setRhs(
                                 Expression.newBuilder()
                                     .setLiteral(
@@ -506,7 +514,8 @@ public class EntityQueryServiceTest {
                             .setLhs(
                                 Expression.newBuilder()
                                     .setColumnIdentifier(
-                                        ColumnIdentifier.newBuilder().setColumnName(API_DISCOVERY_STATE_ATTR)))
+                                        ColumnIdentifier.newBuilder()
+                                            .setColumnName(API_DISCOVERY_STATE_ATTR)))
                             .setRhs(
                                 Expression.newBuilder()
                                     .setLiteral(
@@ -522,7 +531,8 @@ public class EntityQueryServiceTest {
                             .setLhs(
                                 Expression.newBuilder()
                                     .setColumnIdentifier(
-                                        ColumnIdentifier.newBuilder().setColumnName(API_HTTP_URL_ATTR)))
+                                        ColumnIdentifier.newBuilder()
+                                            .setColumnName(API_HTTP_URL_ATTR)))
                             .setRhs(
                                 Expression.newBuilder()
                                     .setLiteral(

--- a/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityQueryServiceTest.java
+++ b/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityQueryServiceTest.java
@@ -719,7 +719,7 @@ public class EntityQueryServiceTest {
   }
 
   @Test
-  public void testBulkUpdate() {
+  public void testBulkUpdate() throws InterruptedException {
     Entity.Builder apiEntityBuilder1 =
         Entity.newBuilder()
             .setTenantId(TENANT_ID)
@@ -798,6 +798,9 @@ public class EntityQueryServiceTest {
 
     GrpcClientRequestContextUtil.executeWithHeadersContext(
         HEADERS, () -> entityQueryServiceClient.bulkUpdate(bulkUpdateRequest));
+
+    // Add a small delay for the update to reflect
+    Thread.sleep(500);
 
     EntityQueryRequest entityQueryRequest =
         EntityQueryRequest.newBuilder()

--- a/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityTypeServiceTest.java
+++ b/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityTypeServiceTest.java
@@ -1,7 +1,5 @@
 package org.hypertrace.entity.service.service;
 
-import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
-
 import com.typesafe.config.ConfigFactory;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -22,45 +20,20 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.utility.DockerImageName;
 
 /** Integration test for testing {@link EntityTypeServiceClient} */
 public class EntityTypeServiceTest {
-  private static final Logger LOG = LoggerFactory.getLogger(EntityTypeServiceTest.class);
-  private static final Slf4jLogConsumer logConsumer = new Slf4jLogConsumer(LOG);
-
   private static final String TENANT_ID =
       "__testTenant__" + EntityTypeServiceTest.class.getSimpleName();
 
   private static EntityTypeServiceClient client;
 
-  private static final int CONTAINER_STARTUP_ATTEMPTS = 5;
-  private static GenericContainer<?> mongo;
   private static ManagedChannel channel;
 
   @BeforeAll
-  public static void setUp() throws Exception {
-
-    mongo =
-        new GenericContainer<>(DockerImageName.parse("hypertrace/mongodb:main"))
-            .withExposedPorts(27017)
-            .withStartupAttempts(CONTAINER_STARTUP_ATTEMPTS)
-            .waitingFor(Wait.forListeningPort())
-            .withLogConsumer(logConsumer);
-    mongo.start();
-
-    withEnvironmentVariable("MONGO_HOST", mongo.getHost())
-        .and("MONGO_PORT", mongo.getMappedPort(27017).toString())
-        .execute(
-            () -> {
-              ConfigFactory.invalidateCaches();
-              IntegrationTestServerUtil.startServices(new String[] {"entity-service"});
-            });
+  public static void setUp() {
+    ConfigFactory.invalidateCaches();
+    IntegrationTestServerUtil.startServices(new String[] {"entity-service"});
     EntityServiceClientConfig entityServiceTestConfig = EntityServiceTestConfig.getClientConfig();
     channel =
         ManagedChannelBuilder.forAddress("localhost", entityServiceTestConfig.getPort())
@@ -73,7 +46,6 @@ public class EntityTypeServiceTest {
   public static void teardown() {
     channel.shutdown();
     IntegrationTestServerUtil.shutdownServices();
-    mongo.stop();
   }
 
   @BeforeEach

--- a/entity-service/src/integrationTest/resources/configs/attribute-service/application.conf
+++ b/entity-service/src/integrationTest/resources/configs/attribute-service/application.conf
@@ -1,0 +1,8 @@
+document.store {
+  dataStoreType = mongo
+  mongo {
+    host = localhost
+    host = ${?mongo_host} # provides a way to override the mongo_host via an environment variable
+    port = 27017
+  }
+}

--- a/entity-service/src/integrationTest/resources/configs/entity-service/application.conf
+++ b/entity-service/src/integrationTest/resources/configs/entity-service/application.conf
@@ -48,7 +48,7 @@ entity.service.attributeMap = [
   {
     "scope": "API",
     "name": "API.httpUrl",
-    "subDocPath": "attributes.API_NAME"
+    "subDocPath": "attributes.http_url"
   },
   {
     "scope": "API",

--- a/entity-service/src/integrationTest/resources/configs/entity-service/application.conf
+++ b/entity-service/src/integrationTest/resources/configs/entity-service/application.conf
@@ -8,7 +8,7 @@ entity.service.config = {
     mongo {
       host = localhost
       host = ${?MONGO_HOST}
-      port = 27017
+      port = 37017
       port = ${?MONGO_PORT}
     }
   }
@@ -16,6 +16,12 @@ entity.service.config = {
 }
 
 entity.query.service.response.chunk.size = 2
+
+attribute.service.config = {
+  host = localhost
+  host = ${?ATTRIBUTE_SERVICE_HOST_CONFIG}
+  port = 9112
+}
 
 # This should be completely driven based on config given in app packaging.
 entity.service.attributeMap = [


### PR DESCRIPTION
## Description
Additional integration test for filtering on composite values (arrays and maps)

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
