### PR TITLE
Fix for single-child filter case of logical expression conversion

### DIFF
--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/FilterConverterFactory.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/FilterConverterFactory.java
@@ -7,6 +7,6 @@ import org.hypertrace.entity.query.service.v1.Filter;
 import org.hypertrace.entity.query.service.v1.Operator;
 
 public interface FilterConverterFactory {
-  Converter<Filter, ? extends FilteringExpression> getFilterConverter(final Operator operator)
+  Converter<Filter, FilteringExpression> getFilterConverter(final Operator operator)
       throws ConversionException;
 }

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/FilterConverterFactoryImpl.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/FilterConverterFactoryImpl.java
@@ -3,7 +3,6 @@ package org.hypertrace.entity.query.service.converter.filter;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import lombok.AllArgsConstructor;
-import org.hypertrace.core.documentstore.expression.impl.LogicalExpression;
 import org.hypertrace.core.documentstore.expression.type.FilteringExpression;
 import org.hypertrace.entity.query.service.converter.ConversionException;
 import org.hypertrace.entity.query.service.converter.Converter;
@@ -13,12 +12,12 @@ import org.hypertrace.entity.query.service.v1.Operator;
 @Singleton
 @AllArgsConstructor(onConstructor_ = {@Inject})
 public class FilterConverterFactoryImpl implements FilterConverterFactory {
-  private final Converter<Filter, FilteringExpression> relationalExpressionConverter;
-  private final Converter<Filter, LogicalExpression> logicalExpressionConverter;
+  private final RelationalExpressionConverter relationalExpressionConverter;
+  private final LogicalExpressionConverter logicalExpressionConverter;
 
   @Override
-  public Converter<Filter, ? extends FilteringExpression> getFilterConverter(
-      final Operator operator) throws ConversionException {
+  public Converter<Filter, FilteringExpression> getFilterConverter(final Operator operator)
+      throws ConversionException {
     switch (operator) {
       case AND:
       case OR:

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/FilterModule.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/FilterModule.java
@@ -2,8 +2,6 @@ package org.hypertrace.entity.query.service.converter.filter;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.TypeLiteral;
-import org.hypertrace.core.documentstore.expression.impl.LogicalExpression;
-import org.hypertrace.core.documentstore.expression.type.FilteringExpression;
 import org.hypertrace.core.documentstore.query.Filter;
 import org.hypertrace.entity.query.service.converter.Converter;
 import org.hypertrace.entity.query.service.v1.EntityQueryRequest;
@@ -14,12 +12,6 @@ public class FilterModule extends AbstractModule {
   protected void configure() {
     bind(new TypeLiteral<Converter<EntityQueryRequest, Filter>>() {}).to(FilterConverter.class);
     bind(FilterConverterFactory.class).to(FilterConverterFactoryImpl.class);
-    bind(new TypeLiteral<
-            Converter<org.hypertrace.entity.query.service.v1.Filter, LogicalExpression>>() {})
-        .to(LogicalExpressionConverter.class);
-    bind(new TypeLiteral<
-            Converter<org.hypertrace.entity.query.service.v1.Filter, FilteringExpression>>() {})
-        .to(RelationalExpressionConverter.class);
     bind(ExtraFiltersApplier.class).to(ExtraFiltersApplierImpl.class);
     bind(FilteringExpressionConverterFactory.class)
         .to(FilteringExpressionConverterFactoryImpl.class);

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/filter/FilterConverterFactoryImplTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/filter/FilterConverterFactoryImplTest.java
@@ -11,11 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.quality.Strictness.LENIENT;
 
-import org.hypertrace.core.documentstore.expression.impl.LogicalExpression;
-import org.hypertrace.core.documentstore.expression.type.FilteringExpression;
 import org.hypertrace.entity.query.service.converter.ConversionException;
-import org.hypertrace.entity.query.service.converter.Converter;
-import org.hypertrace.entity.query.service.v1.Filter;
 import org.hypertrace.entity.query.service.v1.Operator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,8 +25,8 @@ import org.mockito.junit.jupiter.MockitoSettings;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = LENIENT)
 class FilterConverterFactoryImplTest {
-  @Mock private Converter<Filter, FilteringExpression> relationalExpressionConverter;
-  @Mock private Converter<Filter, LogicalExpression> logicalExpressionConverter;
+  @Mock private RelationalExpressionConverter relationalExpressionConverter;
+  @Mock private LogicalExpressionConverter logicalExpressionConverter;
 
   private FilterConverterFactory filterConverterFactory;
 

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/filter/FilterConverterTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/filter/FilterConverterTest.java
@@ -6,13 +6,11 @@ import static org.mockito.quality.Strictness.LENIENT;
 
 import org.hypertrace.core.documentstore.expression.impl.ConstantExpression;
 import org.hypertrace.core.documentstore.expression.impl.IdentifierExpression;
-import org.hypertrace.core.documentstore.expression.impl.LogicalExpression;
 import org.hypertrace.core.documentstore.expression.impl.RelationalExpression;
 import org.hypertrace.core.documentstore.expression.operators.RelationalOperator;
 import org.hypertrace.core.documentstore.expression.type.FilteringExpression;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.entity.query.service.converter.ConversionException;
-import org.hypertrace.entity.query.service.converter.Converter;
 import org.hypertrace.entity.query.service.v1.EntityQueryRequest;
 import org.hypertrace.entity.query.service.v1.Filter;
 import org.hypertrace.entity.query.service.v1.Operator;
@@ -28,8 +26,8 @@ import org.mockito.junit.jupiter.MockitoSettings;
 class FilterConverterTest {
   @Mock private ExtraFiltersApplier extraFiltersApplier;
   @Mock private FilteringExpression allFilters;
-  @Mock private Converter<Filter, LogicalExpression> logicalFilterConverter;
-  @Mock private Converter<Filter, FilteringExpression> relationalExpressionConverter;
+  @Mock private LogicalExpressionConverter logicalFilterConverter;
+  @Mock private RelationalExpressionConverter relationalExpressionConverter;
 
   private final RelationalExpression relationalExpression =
       RelationalExpression.of(

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/filter/LogicalExpressionConverterTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/filter/LogicalExpressionConverterTest.java
@@ -40,7 +40,7 @@ class LogicalExpressionConverterTest {
           .build();
   private final RequestContext requestContext = RequestContext.forTenantId("Martian");
 
-  private Converter<Filter, LogicalExpression> logicalExpressionConverter;
+  private Converter<Filter, FilteringExpression> logicalExpressionConverter;
 
   @BeforeEach
   void setup() throws ConversionException {
@@ -79,5 +79,20 @@ class LogicalExpressionConverterTest {
     assertThrows(
         ConversionException.class,
         () -> logicalExpressionConverter.convert(filter, requestContext));
+  }
+
+  @Test
+  void testEmptyChildFilters() {
+    Filter filter = Filter.newBuilder().setOperator(Operator.AND).build();
+    assertThrows(
+        ConversionException.class,
+        () -> logicalExpressionConverter.convert(filter, requestContext));
+  }
+
+  @Test
+  void testSingleChildFilter() throws ConversionException {
+    Filter filter =
+        Filter.newBuilder().setOperator(Operator.AND).addChildFilter(childFilter1).build();
+    assertEquals(filteringExpression1, logicalExpressionConverter.convert(filter, requestContext));
   }
 }


### PR DESCRIPTION
* Fixed the single-child filter case for Logical Expression conversion
* Handled the empty child filter case for Logical Expression conversion

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Added unit tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
