### PR TITLE
Wrap new query DTO querying under a flag

### DIFF
--- a/entity-service-impl/build.gradle.kts
+++ b/entity-service-impl/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
   annotationProcessor("org.projectlombok:lombok:1.18.22")
   compileOnly("org.projectlombok:lombok:1.18.18")
 
-  implementation("org.hypertrace.core.documentstore:document-store:0.6.7")
+  implementation("org.hypertrace.core.documentstore:document-store:0.6.8")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.7.0")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.7.0")
   implementation("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.12.3")

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryConverter.java
@@ -3,8 +3,11 @@ package org.hypertrace.entity.query.service;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import lombok.Value;
@@ -47,6 +50,112 @@ class EntityQueryConverter {
     queryBuilder.setOffset(queryRequest.getOffset());
 
     return queryBuilder.build();
+  }
+
+  public static org.hypertrace.entity.query.service.v1.Value convertAttributeValueToQueryValue(
+      AttributeValue attributeValue) {
+    if (attributeValue == null) {
+      return org.hypertrace.entity.query.service.v1.Value.getDefaultInstance();
+    }
+    switch (attributeValue.getTypeCase()) {
+      case VALUE:
+        return convertValueToQueryValue(attributeValue.getValue());
+      case VALUE_LIST:
+        // TODO for now converting everything to string array
+        return org.hypertrace.entity.query.service.v1.Value.newBuilder()
+            .setValueType(ValueType.STRING_ARRAY)
+            .addAllStringArray(
+                attributeValue.getValueList().getValuesList().stream()
+                    .map(EntityQueryConverter::toStringWithoutTypeInfo)
+                    .collect(Collectors.toList()))
+            .build();
+      case VALUE_MAP:
+        // TODO for now converting everything to string map
+        Map<String, String> map = new HashMap<>();
+        for (Map.Entry<String, AttributeValue> entry :
+            attributeValue.getValueMap().getValuesMap().entrySet()) {
+          map.put(entry.getKey(), toStringWithoutTypeInfo(entry.getValue()));
+        }
+        return org.hypertrace.entity.query.service.v1.Value.newBuilder()
+            .setValueType(ValueType.STRING_MAP)
+            .putAllStringMap(map)
+            .build();
+      case TYPE_NOT_SET:
+      default:
+        return org.hypertrace.entity.query.service.v1.Value.getDefaultInstance();
+    }
+  }
+
+  public List<String> convertSelectionsToDocStoreSelections(
+      RequestContext requestContext, List<Expression> expressions) {
+    if (expressions.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    List<String> result = new ArrayList<>();
+    for (Expression expression : expressions) {
+      if (expression.hasColumnIdentifier()) {
+        String docStoreColumnName =
+            getAttributeColumnInfo(requestContext, expression).getColumnName();
+        result.add(docStoreColumnName);
+      } else {
+        // entity data service and doc store only support field selection. There's no
+        // aggregate selection yet
+        throw new UnsupportedOperationException(
+            "Expression only support Column Identifier Expression");
+      }
+    }
+    return result;
+  }
+
+  private static org.hypertrace.entity.query.service.v1.Value convertValueToQueryValue(
+      org.hypertrace.entity.data.service.v1.Value value) {
+    switch (value.getTypeCase()) {
+      case STRING:
+        return org.hypertrace.entity.query.service.v1.Value.newBuilder()
+            .setValueType(ValueType.STRING)
+            .setString(value.getString())
+            .build();
+      case BOOLEAN:
+        return org.hypertrace.entity.query.service.v1.Value.newBuilder()
+            .setValueType(ValueType.BOOL)
+            .setBoolean(value.getBoolean())
+            .build();
+      case INT:
+        return org.hypertrace.entity.query.service.v1.Value.newBuilder()
+            .setValueType(ValueType.INT)
+            .setInt(value.getInt())
+            .build();
+      case LONG:
+        return org.hypertrace.entity.query.service.v1.Value.newBuilder()
+            .setValueType(ValueType.LONG)
+            .setLong(value.getLong())
+            .build();
+      case FLOAT:
+        return org.hypertrace.entity.query.service.v1.Value.newBuilder()
+            .setValueType(ValueType.FLOAT)
+            .setFloat(value.getFloat())
+            .build();
+      case DOUBLE:
+        return org.hypertrace.entity.query.service.v1.Value.newBuilder()
+            .setValueType(ValueType.DOUBLE)
+            .setDouble(value.getDouble())
+            .build();
+      case BYTES:
+        return org.hypertrace.entity.query.service.v1.Value.newBuilder()
+            .setValueType(ValueType.BYTES)
+            .setBytes(value.getBytes())
+            .build();
+      case TIMESTAMP:
+        return org.hypertrace.entity.query.service.v1.Value.newBuilder()
+            .setValueType(ValueType.TIMESTAMP)
+            .setTimestamp(value.getTimestamp())
+            .build();
+      case TYPE_NOT_SET:
+      case CUSTOM:
+      default:
+        throw new IllegalStateException("Unexpected value: " + value.getTypeCase());
+    }
   }
 
   private AttributeFilter convertToAttributeFilter(
@@ -261,6 +370,44 @@ class EntityQueryConverter {
         throw new IllegalArgumentException(
             String.format("Attribute Key for expression:%s not found", expression));
     }
+  }
+
+  /**
+   * Method to return the String representation of the given attribute without including any type
+   * information.
+   */
+  private static String toStringWithoutTypeInfo(AttributeValue value) {
+    switch (value.getTypeCase()) {
+      case VALUE:
+        org.hypertrace.entity.data.service.v1.Value inner = value.getValue();
+        switch (inner.getTypeCase()) {
+          case INT:
+            return String.valueOf(inner.getInt());
+          case LONG:
+            return String.valueOf(inner.getLong());
+          case FLOAT:
+            return String.valueOf(inner.getFloat());
+          case DOUBLE:
+            return String.valueOf(inner.getDouble());
+          case TIMESTAMP:
+            return String.valueOf(inner.getTimestamp());
+          case STRING:
+            return inner.getString();
+          case BYTES:
+            return String.valueOf(inner.getBytes());
+          case BOOLEAN:
+            return String.valueOf(inner.getBoolean());
+        }
+        throw new IllegalArgumentException("Unhandled type: " + inner.getTypeCase());
+
+      case VALUE_LIST:
+        String[] values = new String[value.getValueList().getValuesCount()];
+        for (int i = 0; i < value.getValueList().getValuesCount(); i++) {
+          values[i] = toStringWithoutTypeInfo(value.getValueList().getValues(i));
+        }
+        return Arrays.toString(values);
+    }
+    throw new IllegalArgumentException("Unhandled type: " + value.getTypeCase());
   }
 
   private List<org.hypertrace.entity.data.service.v1.OrderByExpression> convertOrderBy(

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryConverter.java
@@ -52,6 +52,10 @@ class EntityQueryConverter {
     return queryBuilder.build();
   }
 
+  @Deprecated(
+      since =
+          "Will be removed when Collection.find() and Collection.aggregate() are implemented for Postgres and the 'queryAggregationEnabled' helm-value is enabled",
+      forRemoval = true)
   public static org.hypertrace.entity.query.service.v1.Value convertAttributeValueToQueryValue(
       AttributeValue attributeValue) {
     if (attributeValue == null) {
@@ -86,6 +90,10 @@ class EntityQueryConverter {
     }
   }
 
+  @Deprecated(
+      since =
+          "Will be removed when Collection.find() and Collection.aggregate() are implemented for Postgres and the 'queryAggregationEnabled' helm-value is enabled",
+      forRemoval = true)
   public List<String> convertSelectionsToDocStoreSelections(
       RequestContext requestContext, List<Expression> expressions) {
     if (expressions.isEmpty()) {
@@ -108,6 +116,10 @@ class EntityQueryConverter {
     return result;
   }
 
+  @Deprecated(
+      since =
+          "Will be removed when Collection.find() and Collection.aggregate() are implemented for Postgres and the 'queryAggregationEnabled' helm-value is enabled",
+      forRemoval = true)
   private static org.hypertrace.entity.query.service.v1.Value convertValueToQueryValue(
       org.hypertrace.entity.data.service.v1.Value value) {
     switch (value.getTypeCase()) {
@@ -376,6 +388,10 @@ class EntityQueryConverter {
    * Method to return the String representation of the given attribute without including any type
    * information.
    */
+  @Deprecated(
+      since =
+          "Will be removed when Collection.find() and Collection.aggregate() are implemented for Postgres and the 'queryAggregationEnabled' helm-value is enabled",
+      forRemoval = true)
   private static String toStringWithoutTypeInfo(AttributeValue value) {
     switch (value.getTypeCase()) {
       case VALUE:

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryServiceImpl.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryServiceImpl.java
@@ -11,6 +11,7 @@ import static org.hypertrace.entity.data.service.v1.AttributeValueList.VALUES_FI
 import static org.hypertrace.entity.query.service.EntityAttributeMapping.ENTITY_ATTRIBUTE_DOC_PREFIX;
 import static org.hypertrace.entity.service.constants.EntityCollectionConstants.RAW_ENTITIES_COLLECTION;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.TypeLiteral;
@@ -122,7 +123,8 @@ public class EntityQueryServiceImpl extends EntityQueryServiceImplBase {
             && config.getBoolean(QUERY_AGGREGATION_ENABLED_CONFIG));
   }
 
-  public EntityQueryServiceImpl(
+  @VisibleForTesting
+  EntityQueryServiceImpl(
       Collection entitiesCollection,
       EntityAttributeMapping entityAttributeMapping,
       int chunkSize,
@@ -541,7 +543,11 @@ public class EntityQueryServiceImpl extends EntityQueryServiceImplBase {
     responseObserver.onCompleted();
   }
 
-  Row convertToEntityQueryResult(
+  @Deprecated(
+      since =
+          "Will be removed when Collection.find() and Collection.aggregate() are implemented for Postgres and the 'queryAggregationEnabled' helm-value is enabled",
+      forRemoval = true)
+  private Row convertToEntityQueryResult(
       RequestContext requestContext, Entity entity, List<Expression> selections) {
     Row.Builder result = Row.newBuilder();
     selections.stream()

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/OrderByConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/OrderByConverter.java
@@ -16,7 +16,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 import lombok.AllArgsConstructor;
 import org.hypertrace.core.documentstore.expression.impl.IdentifierExpression;
-import org.hypertrace.core.documentstore.expression.operators.SortingOrder;
+import org.hypertrace.core.documentstore.expression.operators.SortOrder;
 import org.hypertrace.core.documentstore.query.Sort;
 import org.hypertrace.core.documentstore.query.SortingSpec;
 import org.hypertrace.core.grpcutils.context.RequestContext;
@@ -25,13 +25,12 @@ import org.hypertrace.entity.query.service.v1.ColumnIdentifier;
 import org.hypertrace.entity.query.service.v1.Expression;
 import org.hypertrace.entity.query.service.v1.Expression.ValueCase;
 import org.hypertrace.entity.query.service.v1.OrderByExpression;
-import org.hypertrace.entity.query.service.v1.SortOrder;
 
 @Singleton
 @AllArgsConstructor(onConstructor_ = {@Inject})
 public class OrderByConverter implements Converter<List<OrderByExpression>, Sort> {
-  private static final Supplier<Map<SortOrder, SortingOrder>> ORDER_MAP =
-      memoize(OrderByConverter::getMapping);
+  private static final Supplier<Map<org.hypertrace.entity.query.service.v1.SortOrder, SortOrder>>
+      ORDER_MAP = memoize(OrderByConverter::getMapping);
   private final OneOfAccessor<Expression, ValueCase> expressionAccessor;
   private final AliasProvider<ColumnIdentifier> aliasProvider;
 
@@ -57,7 +56,7 @@ public class OrderByConverter implements Converter<List<OrderByExpression>, Sort
     final String alias = aliasProvider.getAlias(identifier);
     final IdentifierExpression identifierExpression = IdentifierExpression.of(alias);
 
-    final SortingOrder order = ORDER_MAP.get().get(orderBy.getOrder());
+    final SortOrder order = ORDER_MAP.get().get(orderBy.getOrder());
 
     if (order == null) {
       throw new ConversionException(
@@ -67,11 +66,12 @@ public class OrderByConverter implements Converter<List<OrderByExpression>, Sort
     return SortingSpec.of(identifierExpression, order);
   }
 
-  private static Map<SortOrder, SortingOrder> getMapping() {
-    final Map<SortOrder, SortingOrder> map = new EnumMap<>(SortOrder.class);
+  private static Map<org.hypertrace.entity.query.service.v1.SortOrder, SortOrder> getMapping() {
+    final Map<org.hypertrace.entity.query.service.v1.SortOrder, SortOrder> map =
+        new EnumMap<>(org.hypertrace.entity.query.service.v1.SortOrder.class);
 
-    map.put(ASC, SortingOrder.ASC);
-    map.put(DESC, SortingOrder.DESC);
+    map.put(ASC, SortOrder.ASC);
+    map.put(DESC, SortOrder.DESC);
 
     return unmodifiableMap(map);
   }

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/aggregation/GroupByConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/aggregation/GroupByConverter.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import org.hypertrace.core.documentstore.expression.impl.IdentifierExpression;
-import org.hypertrace.core.documentstore.expression.type.GroupingExpression;
+import org.hypertrace.core.documentstore.expression.type.GroupTypeExpression;
 import org.hypertrace.core.documentstore.query.Aggregation;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.entity.query.service.converter.ConversionException;
@@ -30,17 +30,17 @@ public class GroupByConverter implements Converter<List<GroupByExpression>, Aggr
   public Aggregation convert(
       final List<GroupByExpression> groupByExpressions, final RequestContext requestContext)
       throws ConversionException {
-    final List<GroupingExpression> groupingExpressions = new ArrayList<>();
+    final List<GroupTypeExpression> groupTypeExpressions = new ArrayList<>();
 
     for (final GroupByExpression groupBy : groupByExpressions) {
-      final GroupingExpression groupingExpression = convert(groupBy, requestContext);
-      groupingExpressions.add(groupingExpression);
+      final GroupTypeExpression groupTypeExpression = convert(groupBy, requestContext);
+      groupTypeExpressions.add(groupTypeExpression);
     }
 
-    return Aggregation.builder().expressions(groupingExpressions).build();
+    return Aggregation.builder().expressions(groupTypeExpressions).build();
   }
 
-  private GroupingExpression convert(
+  private GroupTypeExpression convert(
       final GroupByExpression groupBy, final RequestContext requestContext)
       throws ConversionException {
     final Expression innerExpression = groupBy.getExpression();

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/ArrayFilteringExpressionConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/ArrayFilteringExpressionConverter.java
@@ -13,7 +13,7 @@ import org.hypertrace.core.documentstore.expression.impl.LogicalExpression;
 import org.hypertrace.core.documentstore.expression.impl.RelationalExpression;
 import org.hypertrace.core.documentstore.expression.operators.LogicalOperator;
 import org.hypertrace.core.documentstore.expression.operators.RelationalOperator;
-import org.hypertrace.core.documentstore.expression.type.FilteringExpression;
+import org.hypertrace.core.documentstore.expression.type.FilterTypeExpression;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.entity.query.service.EntityAttributeMapping;
 import org.hypertrace.entity.query.service.converter.ConversionException;
@@ -39,7 +39,7 @@ public class ArrayFilteringExpressionConverter extends FilteringExpressionConver
   private final ValueHelper valueHelper;
 
   @Override
-  public FilteringExpression convert(
+  public FilterTypeExpression convert(
       final ColumnIdentifier columnIdentifier,
       final Operator operator,
       final LiteralConstant constant,

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/ExtraFiltersApplier.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/ExtraFiltersApplier.java
@@ -1,15 +1,15 @@
 package org.hypertrace.entity.query.service.converter.filter;
 
-import org.hypertrace.core.documentstore.expression.type.FilteringExpression;
+import org.hypertrace.core.documentstore.expression.type.FilterTypeExpression;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.entity.query.service.v1.EntityQueryRequest;
 
 public interface ExtraFiltersApplier {
-  FilteringExpression addExtraFilters(
-      final FilteringExpression filters,
+  FilterTypeExpression addExtraFilters(
+      final FilterTypeExpression filters,
       final EntityQueryRequest entityQueryRequest,
       final RequestContext context);
 
-  FilteringExpression getExtraFilters(
+  FilterTypeExpression getExtraFilters(
       final EntityQueryRequest entityQueryRequest, final RequestContext context);
 }

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/ExtraFiltersApplierImpl.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/ExtraFiltersApplierImpl.java
@@ -10,7 +10,7 @@ import org.hypertrace.core.documentstore.expression.impl.ConstantExpression;
 import org.hypertrace.core.documentstore.expression.impl.IdentifierExpression;
 import org.hypertrace.core.documentstore.expression.impl.LogicalExpression;
 import org.hypertrace.core.documentstore.expression.impl.RelationalExpression;
-import org.hypertrace.core.documentstore.expression.type.FilteringExpression;
+import org.hypertrace.core.documentstore.expression.type.FilterTypeExpression;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.entity.query.service.v1.EntityQueryRequest;
 
@@ -19,7 +19,7 @@ public class ExtraFiltersApplierImpl implements ExtraFiltersApplier {
 
   @Override
   public LogicalExpression addExtraFilters(
-      final FilteringExpression filters,
+      final FilterTypeExpression filters,
       final EntityQueryRequest entityQueryRequest,
       final RequestContext context) {
     final RelationalExpression tenantIdFilter = getTenantIdFilter(context);

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/FilterConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/FilterConverter.java
@@ -3,7 +3,7 @@ package org.hypertrace.entity.query.service.converter.filter;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import lombok.AllArgsConstructor;
-import org.hypertrace.core.documentstore.expression.type.FilteringExpression;
+import org.hypertrace.core.documentstore.expression.type.FilterTypeExpression;
 import org.hypertrace.core.documentstore.query.Filter;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.entity.query.service.converter.ConversionException;
@@ -21,17 +21,17 @@ public class FilterConverter implements Converter<EntityQueryRequest, Filter> {
       throws ConversionException {
     final org.hypertrace.entity.query.service.v1.Filter filter = request.getFilter();
 
-    final FilteringExpression allFilters;
+    final FilterTypeExpression allFilters;
 
     if (org.hypertrace.entity.query.service.v1.Filter.getDefaultInstance().equals(filter)) {
       allFilters = extraFiltersApplier.getExtraFilters(request, requestContext);
     } else {
-      final Converter<org.hypertrace.entity.query.service.v1.Filter, ? extends FilteringExpression>
+      final Converter<org.hypertrace.entity.query.service.v1.Filter, ? extends FilterTypeExpression>
           filterConverter = filterConverterFactory.getFilterConverter(filter.getOperator());
-      final FilteringExpression filteringExpression =
+      final FilterTypeExpression filterTypeExpression =
           filterConverter.convert(filter, requestContext);
       allFilters =
-          extraFiltersApplier.addExtraFilters(filteringExpression, request, requestContext);
+          extraFiltersApplier.addExtraFilters(filterTypeExpression, request, requestContext);
     }
 
     return Filter.builder().expression(allFilters).build();

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/FilterConverterFactory.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/FilterConverterFactory.java
@@ -1,12 +1,12 @@
 package org.hypertrace.entity.query.service.converter.filter;
 
-import org.hypertrace.core.documentstore.expression.type.FilteringExpression;
+import org.hypertrace.core.documentstore.expression.type.FilterTypeExpression;
 import org.hypertrace.entity.query.service.converter.ConversionException;
 import org.hypertrace.entity.query.service.converter.Converter;
 import org.hypertrace.entity.query.service.v1.Filter;
 import org.hypertrace.entity.query.service.v1.Operator;
 
 public interface FilterConverterFactory {
-  Converter<Filter, FilteringExpression> getFilterConverter(final Operator operator)
+  Converter<Filter, FilterTypeExpression> getFilterConverter(final Operator operator)
       throws ConversionException;
 }

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/FilterConverterFactoryImpl.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/FilterConverterFactoryImpl.java
@@ -3,7 +3,7 @@ package org.hypertrace.entity.query.service.converter.filter;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import lombok.AllArgsConstructor;
-import org.hypertrace.core.documentstore.expression.type.FilteringExpression;
+import org.hypertrace.core.documentstore.expression.type.FilterTypeExpression;
 import org.hypertrace.entity.query.service.converter.ConversionException;
 import org.hypertrace.entity.query.service.converter.Converter;
 import org.hypertrace.entity.query.service.v1.Filter;
@@ -16,7 +16,7 @@ public class FilterConverterFactoryImpl implements FilterConverterFactory {
   private final LogicalExpressionConverter logicalExpressionConverter;
 
   @Override
-  public Converter<Filter, FilteringExpression> getFilterConverter(final Operator operator)
+  public Converter<Filter, FilterTypeExpression> getFilterConverter(final Operator operator)
       throws ConversionException {
     switch (operator) {
       case AND:

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/FilteringExpressionConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/FilteringExpressionConverter.java
@@ -1,6 +1,6 @@
 package org.hypertrace.entity.query.service.converter.filter;
 
-import org.hypertrace.core.documentstore.expression.type.FilteringExpression;
+import org.hypertrace.core.documentstore.expression.type.FilterTypeExpression;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.entity.query.service.converter.ConversionException;
 import org.hypertrace.entity.query.service.v1.ColumnIdentifier;
@@ -9,7 +9,7 @@ import org.hypertrace.entity.query.service.v1.Operator;
 
 public interface FilteringExpressionConverter {
 
-  FilteringExpression convert(
+  FilterTypeExpression convert(
       ColumnIdentifier columnIdentifier,
       Operator operator,
       LiteralConstant constant,

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/LogicalExpressionConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/LogicalExpressionConverter.java
@@ -15,7 +15,7 @@ import java.util.function.Supplier;
 import lombok.AllArgsConstructor;
 import org.hypertrace.core.documentstore.expression.impl.LogicalExpression;
 import org.hypertrace.core.documentstore.expression.operators.LogicalOperator;
-import org.hypertrace.core.documentstore.expression.type.FilteringExpression;
+import org.hypertrace.core.documentstore.expression.type.FilterTypeExpression;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.entity.query.service.converter.ConversionException;
 import org.hypertrace.entity.query.service.converter.Converter;
@@ -24,13 +24,13 @@ import org.hypertrace.entity.query.service.v1.Operator;
 
 @Singleton
 @AllArgsConstructor(onConstructor_ = {@Inject})
-public class LogicalExpressionConverter implements Converter<Filter, FilteringExpression> {
+public class LogicalExpressionConverter implements Converter<Filter, FilterTypeExpression> {
   private static final Supplier<Map<Operator, LogicalOperator>> LOGICAL_OPERATOR_MAP =
       Suppliers.memoize(LogicalExpressionConverter::getLogicalOperatorMap);
   private final FilterConverterFactory filterConverterFactory;
 
   @Override
-  public FilteringExpression convert(final Filter filter, final RequestContext requestContext)
+  public FilterTypeExpression convert(final Filter filter, final RequestContext requestContext)
       throws ConversionException {
     final LogicalOperator operator = LOGICAL_OPERATOR_MAP.get().get(filter.getOperator());
 
@@ -44,9 +44,9 @@ public class LogicalExpressionConverter implements Converter<Filter, FilteringEx
           String.format("No child filter found with operator: %s", operator));
     }
 
-    final List<FilteringExpression> innerFilters = new ArrayList<>();
+    final List<FilterTypeExpression> innerFilters = new ArrayList<>();
     for (final Filter innerFilter : filter.getChildFilterList()) {
-      final FilteringExpression expression = convertInnerFilter(innerFilter, requestContext);
+      final FilterTypeExpression expression = convertInnerFilter(innerFilter, requestContext);
       innerFilters.add(expression);
     }
 
@@ -57,9 +57,9 @@ public class LogicalExpressionConverter implements Converter<Filter, FilteringEx
     return LogicalExpression.builder().operator(operator).operands(innerFilters).build();
   }
 
-  private FilteringExpression convertInnerFilter(
+  private FilterTypeExpression convertInnerFilter(
       final Filter filter, final RequestContext requestContext) throws ConversionException {
-    final Converter<Filter, ? extends FilteringExpression> filterConverter =
+    final Converter<Filter, ? extends FilterTypeExpression> filterConverter =
         filterConverterFactory.getFilterConverter(filter.getOperator());
     return filterConverter.convert(filter, requestContext);
   }

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/MapFilteringExpressionConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/MapFilteringExpressionConverter.java
@@ -17,7 +17,7 @@ import org.hypertrace.core.documentstore.expression.impl.LogicalExpression;
 import org.hypertrace.core.documentstore.expression.impl.RelationalExpression;
 import org.hypertrace.core.documentstore.expression.operators.LogicalOperator;
 import org.hypertrace.core.documentstore.expression.operators.RelationalOperator;
-import org.hypertrace.core.documentstore.expression.type.FilteringExpression;
+import org.hypertrace.core.documentstore.expression.type.FilterTypeExpression;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.entity.query.service.EntityAttributeMapping;
 import org.hypertrace.entity.query.service.converter.ConversionException;
@@ -43,7 +43,7 @@ public class MapFilteringExpressionConverter extends FilteringExpressionConverte
   private final ValueHelper valueHelper;
 
   @Override
-  public FilteringExpression convert(
+  public FilterTypeExpression convert(
       final ColumnIdentifier columnIdentifier,
       final Operator operator,
       final LiteralConstant constant,

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/PrimitiveFilteringExpressionConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/PrimitiveFilteringExpressionConverter.java
@@ -9,7 +9,7 @@ import org.hypertrace.core.documentstore.expression.impl.ConstantExpression;
 import org.hypertrace.core.documentstore.expression.impl.IdentifierExpression;
 import org.hypertrace.core.documentstore.expression.impl.RelationalExpression;
 import org.hypertrace.core.documentstore.expression.operators.RelationalOperator;
-import org.hypertrace.core.documentstore.expression.type.FilteringExpression;
+import org.hypertrace.core.documentstore.expression.type.FilterTypeExpression;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.entity.query.service.EntityAttributeMapping;
 import org.hypertrace.entity.query.service.converter.ConversionException;
@@ -31,7 +31,7 @@ public class PrimitiveFilteringExpressionConverter extends FilteringExpressionCo
   private final Converter<LiteralConstant, ConstantExpression> constantExpressionConverter;
 
   @Override
-  public FilteringExpression convert(
+  public FilterTypeExpression convert(
       final ColumnIdentifier columnIdentifier,
       final Operator operator,
       final LiteralConstant constant,

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/RelationalExpressionConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/RelationalExpressionConverter.java
@@ -7,7 +7,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.util.Set;
 import lombok.AllArgsConstructor;
-import org.hypertrace.core.documentstore.expression.type.FilteringExpression;
+import org.hypertrace.core.documentstore.expression.type.FilterTypeExpression;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.entity.query.service.converter.ConversionException;
 import org.hypertrace.entity.query.service.converter.Converter;
@@ -21,12 +21,12 @@ import org.hypertrace.entity.query.service.v1.Operator;
 
 @Singleton
 @AllArgsConstructor(onConstructor_ = {@Inject})
-public class RelationalExpressionConverter implements Converter<Filter, FilteringExpression> {
+public class RelationalExpressionConverter implements Converter<Filter, FilterTypeExpression> {
   private final OneOfAccessor<Expression, ValueCase> expressionAccessor;
   private final FilteringExpressionConverterFactory filteringExpressionConverterFactory;
 
   @Override
-  public FilteringExpression convert(final Filter filter, final RequestContext requestContext)
+  public FilterTypeExpression convert(final Filter filter, final RequestContext requestContext)
       throws ConversionException {
     final Expression lhs = filter.getLhs();
     final Operator operator = filter.getOperator();

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/selection/SelectionConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/selection/SelectionConverter.java
@@ -5,7 +5,7 @@ import com.google.inject.Singleton;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
-import org.hypertrace.core.documentstore.expression.type.SelectingExpression;
+import org.hypertrace.core.documentstore.expression.type.SelectTypeExpression;
 import org.hypertrace.core.documentstore.query.Selection;
 import org.hypertrace.core.documentstore.query.SelectionSpec;
 import org.hypertrace.core.grpcutils.context.RequestContext;
@@ -44,14 +44,14 @@ public class SelectionConverter implements Converter<List<Expression>, Selection
   private <T> SelectionSpec getSpec(
       final ValueCase valueCase, final T innerExpression, final RequestContext requestContext)
       throws ConversionException {
-    final Converter<T, ? extends SelectingExpression> converter =
+    final Converter<T, ? extends SelectTypeExpression> converter =
         selectionFactory.getConverter(valueCase);
     final AliasProvider<T> aliasProvider = selectionFactory.getAliasProvider(valueCase);
 
-    final SelectingExpression selectingExpression =
+    final SelectTypeExpression selectTypeExpression =
         converter.convert(innerExpression, requestContext);
     final String alias = aliasProvider.getAlias(innerExpression);
 
-    return SelectionSpec.of(selectingExpression, alias);
+    return SelectionSpec.of(selectTypeExpression, alias);
   }
 }

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/selection/SelectionFactory.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/selection/SelectionFactory.java
@@ -1,14 +1,14 @@
 package org.hypertrace.entity.query.service.converter.selection;
 
-import org.hypertrace.core.documentstore.expression.type.SelectingExpression;
+import org.hypertrace.core.documentstore.expression.type.SelectTypeExpression;
 import org.hypertrace.entity.query.service.converter.AliasProvider;
 import org.hypertrace.entity.query.service.converter.ConversionException;
 import org.hypertrace.entity.query.service.converter.Converter;
 import org.hypertrace.entity.query.service.v1.Expression;
 
 public interface SelectionFactory {
-  <T> Converter<T, ? extends SelectingExpression> getConverter(final Expression.ValueCase valueCase)
-      throws ConversionException;
+  <T> Converter<T, ? extends SelectTypeExpression> getConverter(
+      final Expression.ValueCase valueCase) throws ConversionException;
 
   <T> AliasProvider<T> getAliasProvider(final Expression.ValueCase valueCase)
       throws ConversionException;

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/selection/SelectionFactoryImpl.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/selection/SelectionFactoryImpl.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 import org.hypertrace.core.documentstore.expression.impl.AggregateExpression;
 import org.hypertrace.core.documentstore.expression.impl.IdentifierExpression;
-import org.hypertrace.core.documentstore.expression.type.SelectingExpression;
+import org.hypertrace.core.documentstore.expression.type.SelectTypeExpression;
 import org.hypertrace.entity.query.service.converter.AliasProvider;
 import org.hypertrace.entity.query.service.converter.ConversionException;
 import org.hypertrace.entity.query.service.converter.Converter;
@@ -30,7 +30,7 @@ public class SelectionFactoryImpl implements SelectionFactory {
       aggregateAliasProvider;
   private final AliasProvider<ColumnIdentifier> identifierAliasProvider;
 
-  private final Supplier<Map<ValueCase, Converter<?, ? extends SelectingExpression>>> converterMap;
+  private final Supplier<Map<ValueCase, Converter<?, ? extends SelectTypeExpression>>> converterMap;
   private final Supplier<Map<ValueCase, AliasProvider<?>>> aliasProviderMap;
 
   @Inject
@@ -54,16 +54,17 @@ public class SelectionFactoryImpl implements SelectionFactory {
 
   @SuppressWarnings("unchecked")
   @Override
-  public <T> Converter<T, ? extends SelectingExpression> getConverter(final ValueCase valueCase)
+  public <T> Converter<T, ? extends SelectTypeExpression> getConverter(final ValueCase valueCase)
       throws ConversionException {
-    final Converter<?, ? extends SelectingExpression> converter = converterMap.get().get(valueCase);
+    final Converter<?, ? extends SelectTypeExpression> converter =
+        converterMap.get().get(valueCase);
 
     if (converter == null) {
       throw new ConversionException(
           String.format("Converter not found for %s", valueCase.toString().toLowerCase()));
     }
 
-    return (Converter<T, ? extends SelectingExpression>) converter;
+    return (Converter<T, ? extends SelectTypeExpression>) converter;
   }
 
   @SuppressWarnings("unchecked")
@@ -80,8 +81,8 @@ public class SelectionFactoryImpl implements SelectionFactory {
     return (AliasProvider<T>) aliasProvider;
   }
 
-  private Map<ValueCase, Converter<?, ? extends SelectingExpression>> getConverterMap() {
-    final Map<ValueCase, Converter<?, ? extends SelectingExpression>> map =
+  private Map<ValueCase, Converter<?, ? extends SelectTypeExpression>> getConverterMap() {
+    final Map<ValueCase, Converter<?, ? extends SelectTypeExpression>> map =
         new EnumMap<>(ValueCase.class);
 
     map.put(AGGREGATION, aggregateExpressionConverter);

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/EntityQueryServiceImplTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/EntityQueryServiceImplTest.java
@@ -90,7 +90,7 @@ public class EntityQueryServiceImplTest {
         .call(
             () -> {
               EntityQueryServiceImpl eqs =
-                  new EntityQueryServiceImpl(entitiesCollection, mockAttributeMapping, 1);
+                  new EntityQueryServiceImpl(entitiesCollection, mockAttributeMapping, 1, false);
 
               eqs.update(null, mockResponseObserver);
 
@@ -110,7 +110,7 @@ public class EntityQueryServiceImplTest {
         .call(
             () -> {
               EntityQueryServiceImpl eqs =
-                  new EntityQueryServiceImpl(entitiesCollection, mockAttributeMapping, 1);
+                  new EntityQueryServiceImpl(entitiesCollection, mockAttributeMapping, 1, false);
 
               eqs.update(EntityUpdateRequest.newBuilder().build(), mockResponseObserver);
 
@@ -131,7 +131,7 @@ public class EntityQueryServiceImplTest {
         .call(
             () -> {
               EntityQueryServiceImpl eqs =
-                  new EntityQueryServiceImpl(entitiesCollection, mockAttributeMapping, 1);
+                  new EntityQueryServiceImpl(entitiesCollection, mockAttributeMapping, 1, false);
 
               eqs.update(
                   EntityUpdateRequest.newBuilder().setEntityType(TEST_ENTITY_TYPE).build(),
@@ -154,7 +154,7 @@ public class EntityQueryServiceImplTest {
         .call(
             () -> {
               EntityQueryServiceImpl eqs =
-                  new EntityQueryServiceImpl(entitiesCollection, mockAttributeMapping, 1);
+                  new EntityQueryServiceImpl(entitiesCollection, mockAttributeMapping, 1, false);
 
               eqs.update(
                   EntityUpdateRequest.newBuilder()
@@ -207,7 +207,7 @@ public class EntityQueryServiceImplTest {
             () -> {
               EntityQueryServiceImpl eqs =
                   new EntityQueryServiceImpl(
-                      mockEntitiesCollection, mockMappingForAttributes1And2(), 1);
+                      mockEntitiesCollection, mockMappingForAttributes1And2(), 1, false);
               eqs.update(updateRequest, mockResponseObserver);
               return null;
             });
@@ -233,7 +233,7 @@ public class EntityQueryServiceImplTest {
           .call(
               () -> {
                 EntityQueryServiceImpl eqs =
-                    new EntityQueryServiceImpl(entitiesCollection, mockAttributeMapping, 1);
+                    new EntityQueryServiceImpl(entitiesCollection, mockAttributeMapping, 1, false);
 
                 eqs.bulkUpdate(null, mockResponseObserver);
 
@@ -254,7 +254,7 @@ public class EntityQueryServiceImplTest {
           .call(
               () -> {
                 EntityQueryServiceImpl eqs =
-                    new EntityQueryServiceImpl(entitiesCollection, mockAttributeMapping, 1);
+                    new EntityQueryServiceImpl(entitiesCollection, mockAttributeMapping, 1, false);
 
                 eqs.bulkUpdate(BulkEntityUpdateRequest.newBuilder().build(), mockResponseObserver);
 
@@ -275,7 +275,7 @@ public class EntityQueryServiceImplTest {
           .call(
               () -> {
                 EntityQueryServiceImpl eqs =
-                    new EntityQueryServiceImpl(entitiesCollection, mockAttributeMapping, 1);
+                    new EntityQueryServiceImpl(entitiesCollection, mockAttributeMapping, 1, false);
 
                 eqs.bulkUpdate(
                     BulkEntityUpdateRequest.newBuilder().setEntityType(TEST_ENTITY_TYPE).build(),
@@ -305,7 +305,7 @@ public class EntityQueryServiceImplTest {
           .call(
               () -> {
                 EntityQueryServiceImpl eqs =
-                    new EntityQueryServiceImpl(entitiesCollection, mockAttributeMapping, 1);
+                    new EntityQueryServiceImpl(entitiesCollection, mockAttributeMapping, 1, false);
                 eqs.bulkUpdate(bulkUpdateRequest, mockResponseObserver);
                 return null;
               });
@@ -342,7 +342,7 @@ public class EntityQueryServiceImplTest {
               () -> {
                 EntityQueryServiceImpl eqs =
                     new EntityQueryServiceImpl(
-                        mockEntitiesCollection, mockMappingForAttribute1(), 1);
+                        mockEntitiesCollection, mockMappingForAttribute1(), 1, false);
                 eqs.bulkUpdate(bulkUpdateRequest, mockResponseObserver);
                 return null;
               });
@@ -366,7 +366,7 @@ public class EntityQueryServiceImplTest {
         .call(
             () -> {
               EntityQueryServiceImpl eqs =
-                  new EntityQueryServiceImpl(entitiesCollection, mockAttributeMapping, 1);
+                  new EntityQueryServiceImpl(entitiesCollection, mockAttributeMapping, 1, false);
 
               eqs.execute(null, mockResponseObserver);
 
@@ -434,7 +434,7 @@ public class EntityQueryServiceImplTest {
             () -> {
               EntityQueryServiceImpl eqs =
                   new EntityQueryServiceImpl(
-                      mockEntitiesCollection, mockMappingForAttributes1And2(), 1);
+                      mockEntitiesCollection, mockMappingForAttributes1And2(), 1, false);
 
               eqs.execute(request, mockResponseObserver);
               return null;
@@ -519,7 +519,7 @@ public class EntityQueryServiceImplTest {
             () -> {
               EntityQueryServiceImpl eqs =
                   new EntityQueryServiceImpl(
-                      mockEntitiesCollection, mockMappingForAttributes1And2(), 2);
+                      mockEntitiesCollection, mockMappingForAttributes1And2(), 2, false);
 
               eqs.execute(request, mockResponseObserver);
               return null;
@@ -564,7 +564,7 @@ public class EntityQueryServiceImplTest {
         .call(
             () -> {
               EntityQueryServiceImpl eqs =
-                  new EntityQueryServiceImpl(entitiesCollection, mockAttributeMapping, 1);
+                  new EntityQueryServiceImpl(entitiesCollection, mockAttributeMapping, 1, false);
               eqs.bulkUpdateEntityArrayAttribute(request, mockResponseObserver);
               return null;
             });
@@ -641,7 +641,7 @@ public class EntityQueryServiceImplTest {
             () -> {
               EntityQueryServiceImpl eqs =
                   new EntityQueryServiceImpl(
-                      mockEntitiesCollection, mockMappingForAttributes1And2(), 100);
+                      mockEntitiesCollection, mockMappingForAttributes1And2(), 100, false);
 
               eqs.execute(request, mockResponseObserver);
             });
@@ -677,7 +677,7 @@ public class EntityQueryServiceImplTest {
       ArgumentCaptor<Query> docStoreQueryCaptor = ArgumentCaptor.forClass(Query.class);
 
       EntityQueryServiceImpl eqs =
-          new EntityQueryServiceImpl(entitiesCollection, mockAttributeMapping, 1);
+          new EntityQueryServiceImpl(entitiesCollection, mockAttributeMapping, 1, false);
       StreamObserver<TotalEntitiesResponse> mockResponseObserver = mock(StreamObserver.class);
 
       Context.current()
@@ -713,7 +713,7 @@ public class EntityQueryServiceImplTest {
               .build();
 
       EntityQueryServiceImpl eqs =
-          new EntityQueryServiceImpl(entitiesCollection, mockAttributeMapping, 1);
+          new EntityQueryServiceImpl(entitiesCollection, mockAttributeMapping, 1, false);
       StreamObserver<TotalEntitiesResponse> mockResponseObserver = mock(StreamObserver.class);
 
       when(entitiesCollection.total(any())).thenReturn(123L);

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/EntityQueryServiceImplTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/EntityQueryServiceImplTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.quality.Strictness.LENIENT;
 
 import com.google.protobuf.util.JsonFormat;
 import io.grpc.Context;
@@ -52,6 +53,7 @@ import org.hypertrace.entity.query.service.v1.UpdateOperation;
 import org.hypertrace.entity.query.service.v1.Value;
 import org.hypertrace.entity.query.service.v1.ValueType;
 import org.hypertrace.entity.service.util.DocStoreJsonFormat;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -61,8 +63,10 @@ import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = LENIENT)
 public class EntityQueryServiceImplTest {
 
   private static final String TEST_ENTITY_TYPE = "TEST_ENTITY";
@@ -410,6 +414,7 @@ public class EntityQueryServiceImplTest {
             // this doc will result in parsing error
             new JSONDocument("{\"entityId\": [1, 2]}"));
     when(mockEntitiesCollection.aggregate(any())).thenReturn(docs.iterator());
+    when(mockEntitiesCollection.search(any())).thenReturn(docs.iterator());
     EntityQueryRequest request =
         EntityQueryRequest.newBuilder()
             .setEntityType(TEST_ENTITY_TYPE)
@@ -428,13 +433,15 @@ public class EntityQueryServiceImplTest {
         .call(
             () -> {
               EntityQueryServiceImpl eqs =
-                  new EntityQueryServiceImpl(mockEntitiesCollection, mockAttributeMapping, 1);
+                  new EntityQueryServiceImpl(
+                      mockEntitiesCollection, mockMappingForAttributes1And2(), 1);
 
               eqs.execute(request, mockResponseObserver);
               return null;
             });
 
-    verify(mockEntitiesCollection, times(1)).aggregate(any());
+    verify(mockEntitiesCollection, times(0)).aggregate(any());
+    verify(mockEntitiesCollection, times(1)).search(any());
     verify(mockResponseObserver, times(3)).onNext(any());
     verify(mockResponseObserver, times(1)).onCompleted();
   }
@@ -491,6 +498,8 @@ public class EntityQueryServiceImplTest {
             // this doc will result in parsing error
             new JSONDocument("{\"entityId\": [1, 2]}"));
     when(mockEntitiesCollection.aggregate(any())).thenReturn(docs.iterator());
+    when(mockEntitiesCollection.search(any())).thenReturn(docs.iterator());
+
     EntityQueryRequest request =
         EntityQueryRequest.newBuilder()
             .setEntityType(TEST_ENTITY_TYPE)
@@ -509,13 +518,15 @@ public class EntityQueryServiceImplTest {
         .call(
             () -> {
               EntityQueryServiceImpl eqs =
-                  new EntityQueryServiceImpl(mockEntitiesCollection, mockAttributeMapping, 2);
+                  new EntityQueryServiceImpl(
+                      mockEntitiesCollection, mockMappingForAttributes1And2(), 2);
 
               eqs.execute(request, mockResponseObserver);
               return null;
             });
 
-    verify(mockEntitiesCollection, times(1)).aggregate(any());
+    verify(mockEntitiesCollection, times(0)).aggregate(any());
+    verify(mockEntitiesCollection, times(1)).search(any());
     verify(mockResponseObserver, times(2)).onNext(any());
     verify(mockResponseObserver, times(1)).onCompleted();
   }
@@ -578,6 +589,7 @@ public class EntityQueryServiceImplTest {
   }
 
   @Test
+  @Disabled("Disabled until we enable querying based on the new Query DTO")
   public void testExecute_withAliases() throws Exception {
     Collection mockEntitiesCollection = mock(Collection.class);
     List<Document> docs =
@@ -605,6 +617,8 @@ public class EntityQueryServiceImplTest {
                     + "    }\n"
                     + "}"));
     when(mockEntitiesCollection.aggregate(any())).thenReturn(docs.iterator());
+    when(mockEntitiesCollection.search(any())).thenReturn(docs.iterator());
+
     EntityQueryRequest request =
         EntityQueryRequest.newBuilder()
             .setEntityType(TEST_ENTITY_TYPE)

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/OrderByConverterTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/OrderByConverterTest.java
@@ -6,7 +6,7 @@ import static org.mockito.quality.Strictness.LENIENT;
 
 import java.util.List;
 import org.hypertrace.core.documentstore.expression.impl.IdentifierExpression;
-import org.hypertrace.core.documentstore.expression.operators.SortingOrder;
+import org.hypertrace.core.documentstore.expression.operators.SortOrder;
 import org.hypertrace.core.documentstore.query.Sort;
 import org.hypertrace.core.documentstore.query.SortingSpec;
 import org.hypertrace.core.grpcutils.context.RequestContext;
@@ -17,7 +17,6 @@ import org.hypertrace.entity.query.service.v1.ColumnIdentifier;
 import org.hypertrace.entity.query.service.v1.Expression;
 import org.hypertrace.entity.query.service.v1.Expression.ValueCase;
 import org.hypertrace.entity.query.service.v1.OrderByExpression;
-import org.hypertrace.entity.query.service.v1.SortOrder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,7 +41,7 @@ class OrderByConverterTest {
   private final OrderByExpression orderByExpression =
       OrderByExpression.newBuilder()
           .setExpression(Expression.newBuilder().setColumnIdentifier(columnIdentifier))
-          .setOrder(SortOrder.ASC)
+          .setOrder(org.hypertrace.entity.query.service.v1.SortOrder.ASC)
           .build();
 
   @BeforeEach
@@ -54,13 +53,17 @@ class OrderByConverterTest {
   @Test
   void testConvert() throws ConversionException {
     Sort expected =
-        Sort.builder().sortingSpec(SortingSpec.of(identifierExpression, SortingOrder.ASC)).build();
+        Sort.builder().sortingSpec(SortingSpec.of(identifierExpression, SortOrder.ASC)).build();
     assertEquals(expected, orderByConverter.convert(List.of(orderByExpression), requestContext));
   }
 
   @ParameterizedTest
-  @EnumSource(value = SortOrder.class, mode = Mode.EXCLUDE, names = "UNRECOGNIZED")
-  void testConvertCoverage(final SortOrder sortOrder) throws ConversionException {
+  @EnumSource(
+      value = org.hypertrace.entity.query.service.v1.SortOrder.class,
+      mode = Mode.EXCLUDE,
+      names = "UNRECOGNIZED")
+  void testConvertCoverage(final org.hypertrace.entity.query.service.v1.SortOrder sortOrder)
+      throws ConversionException {
     OrderByExpression orderByExpression =
         OrderByExpression.newBuilder()
             .setExpression(Expression.newBuilder().setColumnIdentifier(columnIdentifier))

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/filter/ExtraFiltersApplierTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/filter/ExtraFiltersApplierTest.java
@@ -11,7 +11,7 @@ import org.hypertrace.core.documentstore.expression.impl.ConstantExpression;
 import org.hypertrace.core.documentstore.expression.impl.IdentifierExpression;
 import org.hypertrace.core.documentstore.expression.impl.LogicalExpression;
 import org.hypertrace.core.documentstore.expression.impl.RelationalExpression;
-import org.hypertrace.core.documentstore.expression.type.FilteringExpression;
+import org.hypertrace.core.documentstore.expression.type.FilterTypeExpression;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.entity.query.service.v1.EntityQueryRequest;
 import org.junit.jupiter.api.Test;
@@ -25,7 +25,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 public class ExtraFiltersApplierTest {
   private final ExtraFiltersApplier extraFiltersApplier = new ExtraFiltersApplierImpl();
 
-  @Mock private FilteringExpression filter;
+  @Mock private FilterTypeExpression filter;
 
   private final String tenantId = "Mars-man";
   private final String entityType = "SERVICE";

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/filter/FilterConverterTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/filter/FilterConverterTest.java
@@ -8,7 +8,7 @@ import org.hypertrace.core.documentstore.expression.impl.ConstantExpression;
 import org.hypertrace.core.documentstore.expression.impl.IdentifierExpression;
 import org.hypertrace.core.documentstore.expression.impl.RelationalExpression;
 import org.hypertrace.core.documentstore.expression.operators.RelationalOperator;
-import org.hypertrace.core.documentstore.expression.type.FilteringExpression;
+import org.hypertrace.core.documentstore.expression.type.FilterTypeExpression;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.entity.query.service.converter.ConversionException;
 import org.hypertrace.entity.query.service.v1.EntityQueryRequest;
@@ -25,7 +25,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 @MockitoSettings(strictness = LENIENT)
 class FilterConverterTest {
   @Mock private ExtraFiltersApplier extraFiltersApplier;
-  @Mock private FilteringExpression allFilters;
+  @Mock private FilterTypeExpression allFilters;
   @Mock private LogicalExpressionConverter logicalFilterConverter;
   @Mock private RelationalExpressionConverter relationalExpressionConverter;
 

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/filter/LogicalExpressionConverterTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/filter/LogicalExpressionConverterTest.java
@@ -9,7 +9,7 @@ import static org.mockito.quality.Strictness.LENIENT;
 
 import org.hypertrace.core.documentstore.expression.impl.LogicalExpression;
 import org.hypertrace.core.documentstore.expression.impl.RelationalExpression;
-import org.hypertrace.core.documentstore.expression.type.FilteringExpression;
+import org.hypertrace.core.documentstore.expression.type.FilterTypeExpression;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.entity.query.service.converter.ConversionException;
 import org.hypertrace.entity.query.service.converter.Converter;
@@ -27,8 +27,8 @@ import org.mockito.junit.jupiter.MockitoSettings;
 class LogicalExpressionConverterTest {
   @Mock private FilterConverterFactory filterConverterFactory;
   @Mock private Converter<Filter, RelationalExpression> relationalExpressionConverter;
-  @Mock private FilteringExpression filteringExpression1;
-  @Mock private FilteringExpression filteringExpression2;
+  @Mock private FilterTypeExpression filteringExpression1;
+  @Mock private FilterTypeExpression filteringExpression2;
 
   private final Filter childFilter1 = Filter.newBuilder().setOperator(Operator.AND).build();
   private final Filter childFilter2 = Filter.newBuilder().setOperator(Operator.OR).build();
@@ -40,7 +40,7 @@ class LogicalExpressionConverterTest {
           .build();
   private final RequestContext requestContext = RequestContext.forTenantId("Martian");
 
-  private Converter<Filter, FilteringExpression> logicalExpressionConverter;
+  private Converter<Filter, FilterTypeExpression> logicalExpressionConverter;
 
   @BeforeEach
   void setup() throws ConversionException {

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/filter/RelationalExpressionConverterTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/filter/RelationalExpressionConverterTest.java
@@ -10,7 +10,7 @@ import org.hypertrace.core.documentstore.expression.impl.ConstantExpression;
 import org.hypertrace.core.documentstore.expression.impl.IdentifierExpression;
 import org.hypertrace.core.documentstore.expression.impl.RelationalExpression;
 import org.hypertrace.core.documentstore.expression.operators.RelationalOperator;
-import org.hypertrace.core.documentstore.expression.type.FilteringExpression;
+import org.hypertrace.core.documentstore.expression.type.FilterTypeExpression;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.entity.query.service.converter.ConversionException;
 import org.hypertrace.entity.query.service.converter.Converter;
@@ -53,7 +53,7 @@ class RelationalExpressionConverterTest {
   private final IdentifierExpression identifierExpression = IdentifierExpression.of("planet");
   private final ConstantExpression constantExpression = ConstantExpression.of("Pluto");
 
-  private Converter<Filter, FilteringExpression> relationalExpressionConverter;
+  private Converter<Filter, FilterTypeExpression> relationalExpressionConverter;
 
   @BeforeEach
   void setup() throws ConversionException {

--- a/entity-service/build.gradle.kts
+++ b/entity-service/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
   implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.7.0")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.7.0")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.28")
-  implementation("org.hypertrace.core.documentstore:document-store:0.6.7")
+  implementation("org.hypertrace.core.documentstore:document-store:0.6.8")
 
   runtimeOnly("io.grpc:grpc-netty:1.43.1")
 

--- a/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityQueryServiceTest.java
+++ b/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityQueryServiceTest.java
@@ -91,6 +91,7 @@ import org.hypertrace.entity.v1.entitytype.EntityType;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -599,6 +600,7 @@ public class EntityQueryServiceTest {
   }
 
   @Test
+  @Disabled("Disabled until we enable querying based on the new Query DTO")
   void testExecuteWithEqualsArrayFilter() {
     String filterValue1 = generateRandomUUID();
     String filterValue2 = generateRandomUUID();
@@ -909,6 +911,7 @@ public class EntityQueryServiceTest {
   }
 
   @Test
+  @Disabled("Disabled until we enable querying based on the new Query DTO")
   void testExecuteWithAggregations() {
     // create and upsert some entities
     Entity entity1 =

--- a/entity-service/src/main/resources/configs/common/application.conf
+++ b/entity-service/src/main/resources/configs/common/application.conf
@@ -12,6 +12,7 @@ entity.service.config = {
     }
   }
   publish.change.events = false
+  query.aggregation.enabled = false
 }
 attribute.service.config = {
   host = localhost

--- a/helm/templates/entity-service-config.yaml
+++ b/helm/templates/entity-service-config.yaml
@@ -19,6 +19,7 @@ data:
         }
       }
       publish.change.events = {{ .Values.entityServiceConfig.publishChangeEvents }}
+      query.aggregation.enabled = {{ .Values.entityServiceConfig.queryAggregationEnabled }}
     }
     attribute.service.config = {
       host = {{ .Values.entityServiceConfig.attributeService.host }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -86,6 +86,7 @@ serviceSelectorLabels:
 entityServiceConfig:
   name: entity-service-config
   publishChangeEvents: false
+  queryAggregationEnabled: false
   dataStoreType: "mongo"
   mongo:
     host: mongo


### PR DESCRIPTION
* Surround the new query DTO querying under a disabled flag with the old query DTO querying as default
* Updated the document store version with renamed classes

## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Executed end-to-end tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
