### PR TITLE
Remove redundant protos

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -6,4 +6,8 @@ ignore:
     - '*':
         reason: None Given
         expires: 2022-03-31T00:00:00.000Z
+  SNYK-JAVA-ORGJETBRAINSKOTLIN-2393744:
+    - '*':
+        reason: None Given
+        expires: 2022-12-31T00:00:00.000Z
 patch: {}

--- a/entity-service-api/src/main/proto/org/hypertrace/entity/query/service/v1/entity_query_request.proto
+++ b/entity-service-api/src/main/proto/org/hypertrace/entity/query/service/v1/entity_query_request.proto
@@ -15,7 +15,7 @@ message EntityQueryRequest {
   repeated OrderByExpression orderBy = 7;
   int32 limit = 5;
   int32 offset = 6;
-  repeated GroupByExpression groupBy = 8;
+  repeated Expression groupBy = 8;
 }
 
 message EntityUpdateRequest {

--- a/entity-service-api/src/main/proto/org/hypertrace/entity/query/service/v1/request.proto
+++ b/entity-service-api/src/main/proto/org/hypertrace/entity/query/service/v1/request.proto
@@ -12,7 +12,6 @@ message Expression {
     LiteralConstant literal = 2;
     Function function = 3;
     OrderByExpression orderBy = 4;
-    AggregateExpression aggregation = 5;
   }
 }
 
@@ -62,27 +61,7 @@ message OrderByExpression {
   SortOrder order = 2;
 }
 
-message GroupByExpression {
-  Expression expression = 1;
-}
-
 enum SortOrder {
   ASC = 0;
   DESC = 1;
-}
-
-message AggregateExpression {
-  AggregationOperator operator = 1;
-  Expression expression = 2;
-}
-
-enum AggregationOperator {
-  AGGREGATION_OPERATOR_UNSPECIFIED = 0;
-  AGGREGATION_OPERATOR_AVG = 1;
-  AGGREGATION_OPERATOR_MIN = 2;
-  AGGREGATION_OPERATOR_MAX = 3;
-  AGGREGATION_OPERATOR_SUM = 4;
-  AGGREGATION_OPERATOR_COUNT = 5;
-  AGGREGATION_OPERATOR_DISTINCT_COUNT = 6;
-  AGGREGATION_OPERATOR_DISTINCT = 7;
 }

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryServiceImpl.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryServiceImpl.java
@@ -609,7 +609,7 @@ public class EntityQueryServiceImpl extends EntityQueryServiceImplBase {
     for (final Expression selection : selections) {
       final String columnName;
 
-      if (selection.hasAggregation()) {
+      if (selection.hasFunction()) {
         columnName = aggregateExpressionAliasProvider.getAlias(selection.getFunction());
       } else if (selection.hasColumnIdentifier()) {
         columnName = identifierAliasProvider.getAlias(selection.getColumnIdentifier());

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/QueryConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/QueryConverter.java
@@ -16,7 +16,6 @@ import org.hypertrace.core.documentstore.query.Sort;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.entity.query.service.v1.EntityQueryRequest;
 import org.hypertrace.entity.query.service.v1.Expression;
-import org.hypertrace.entity.query.service.v1.GroupByExpression;
 import org.hypertrace.entity.query.service.v1.OrderByExpression;
 
 @Singleton
@@ -25,7 +24,7 @@ public class QueryConverter implements Converter<EntityQueryRequest, Query> {
   private final Converter<List<Expression>, Selection> selectionConverter;
   private final Converter<EntityQueryRequest, Filter> filterConverter;
 
-  private final Converter<List<GroupByExpression>, Aggregation> groupByConverter;
+  private final Converter<List<Expression>, Aggregation> groupByConverter;
 
   private final Converter<List<OrderByExpression>, Sort> orderByConverter;
   private final PaginationBuilder paginationBuilder = Pagination.builder();

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/accessor/ExpressionOneOfAccessor.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/accessor/ExpressionOneOfAccessor.java
@@ -1,7 +1,6 @@
 package org.hypertrace.entity.query.service.converter.accessor;
 
 import static java.util.Collections.unmodifiableMap;
-import static org.hypertrace.entity.query.service.v1.Expression.ValueCase.AGGREGATION;
 import static org.hypertrace.entity.query.service.v1.Expression.ValueCase.COLUMNIDENTIFIER;
 import static org.hypertrace.entity.query.service.v1.Expression.ValueCase.FUNCTION;
 import static org.hypertrace.entity.query.service.v1.Expression.ValueCase.LITERAL;
@@ -25,7 +24,6 @@ public class ExpressionOneOfAccessor extends OneOfAccessorBase<Expression, Value
     map.put(LITERAL, Expression::getLiteral);
     map.put(FUNCTION, Expression::getFunction);
     map.put(ORDERBY, Expression::getOrderBy);
-    map.put(AGGREGATION, Expression::getAggregation);
 
     return unmodifiableMap(map);
   }

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/aggregation/AggregationModule.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/aggregation/AggregationModule.java
@@ -7,8 +7,8 @@ import org.hypertrace.core.documentstore.expression.impl.AggregateExpression;
 import org.hypertrace.core.documentstore.query.Aggregation;
 import org.hypertrace.entity.query.service.converter.AliasProvider;
 import org.hypertrace.entity.query.service.converter.Converter;
+import org.hypertrace.entity.query.service.v1.Expression;
 import org.hypertrace.entity.query.service.v1.Function;
-import org.hypertrace.entity.query.service.v1.GroupByExpression;
 
 public class AggregationModule extends AbstractModule {
 
@@ -17,7 +17,6 @@ public class AggregationModule extends AbstractModule {
     bind(new TypeLiteral<Converter<Function, AggregateExpression>>() {})
         .to(AggregateExpressionConverter.class);
     bind(new TypeLiteral<AliasProvider<Function>>() {}).to(AggregationAliasProvider.class);
-    bind(new TypeLiteral<Converter<List<GroupByExpression>, Aggregation>>() {})
-        .to(GroupByConverter.class);
+    bind(new TypeLiteral<Converter<List<Expression>, Aggregation>>() {}).to(GroupByConverter.class);
   }
 }

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/aggregation/GroupByConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/aggregation/GroupByConverter.java
@@ -18,21 +18,20 @@ import org.hypertrace.entity.query.service.converter.accessor.OneOfAccessor;
 import org.hypertrace.entity.query.service.v1.ColumnIdentifier;
 import org.hypertrace.entity.query.service.v1.Expression;
 import org.hypertrace.entity.query.service.v1.Expression.ValueCase;
-import org.hypertrace.entity.query.service.v1.GroupByExpression;
 
 @Singleton
 @AllArgsConstructor(onConstructor_ = {@Inject})
-public class GroupByConverter implements Converter<List<GroupByExpression>, Aggregation> {
+public class GroupByConverter implements Converter<List<Expression>, Aggregation> {
   private final OneOfAccessor<Expression, ValueCase> expressionAccessor;
   private final Converter<ColumnIdentifier, IdentifierExpression> identifierExpressionConverter;
 
   @Override
   public Aggregation convert(
-      final List<GroupByExpression> groupByExpressions, final RequestContext requestContext)
+      final List<Expression> Expressions, final RequestContext requestContext)
       throws ConversionException {
     final List<GroupTypeExpression> groupTypeExpressions = new ArrayList<>();
 
-    for (final GroupByExpression groupBy : groupByExpressions) {
+    for (final Expression groupBy : Expressions) {
       final GroupTypeExpression groupTypeExpression = convert(groupBy, requestContext);
       groupTypeExpressions.add(groupTypeExpression);
     }
@@ -40,14 +39,10 @@ public class GroupByConverter implements Converter<List<GroupByExpression>, Aggr
     return Aggregation.builder().expressions(groupTypeExpressions).build();
   }
 
-  private GroupTypeExpression convert(
-      final GroupByExpression groupBy, final RequestContext requestContext)
+  private GroupTypeExpression convert(final Expression groupBy, final RequestContext requestContext)
       throws ConversionException {
-    final Expression innerExpression = groupBy.getExpression();
-
     final ColumnIdentifier identifier =
-        expressionAccessor.access(
-            innerExpression, innerExpression.getValueCase(), Set.of(COLUMNIDENTIFIER));
+        expressionAccessor.access(groupBy, groupBy.getValueCase(), Set.of(COLUMNIDENTIFIER));
 
     return identifierExpressionConverter.convert(identifier, requestContext);
   }

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/accessor/ExpressionOneOfAccessorTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/accessor/ExpressionOneOfAccessorTest.java
@@ -1,6 +1,5 @@
 package org.hypertrace.entity.query.service.converter.accessor;
 
-import static org.hypertrace.entity.query.service.v1.Expression.ValueCase.AGGREGATION;
 import static org.hypertrace.entity.query.service.v1.Expression.ValueCase.COLUMNIDENTIFIER;
 import static org.hypertrace.entity.query.service.v1.Expression.ValueCase.FUNCTION;
 import static org.hypertrace.entity.query.service.v1.Expression.ValueCase.LITERAL;
@@ -15,7 +14,6 @@ import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
 import java.util.Set;
 import org.hypertrace.entity.query.service.converter.ConversionException;
-import org.hypertrace.entity.query.service.v1.AggregateExpression;
 import org.hypertrace.entity.query.service.v1.ColumnIdentifier;
 import org.hypertrace.entity.query.service.v1.Expression;
 import org.hypertrace.entity.query.service.v1.Expression.ValueCase;
@@ -52,9 +50,6 @@ class ExpressionOneOfAccessorTest {
     assertEquals(Function.getDefaultInstance(), expressionAccessor.access(expression, FUNCTION));
     assertEquals(
         OrderByExpression.getDefaultInstance(), expressionAccessor.access(expression, ORDERBY));
-    assertEquals(
-        AggregateExpression.getDefaultInstance(),
-        expressionAccessor.access(expression, AGGREGATION));
   }
 
   @Test
@@ -72,9 +67,5 @@ class ExpressionOneOfAccessorTest {
     assertThrows(
         ConversionException.class,
         () -> expressionAccessor.access(expression, ORDERBY, Set.of(COLUMNIDENTIFIER, LITERAL)));
-    assertThrows(
-        ConversionException.class,
-        () ->
-            expressionAccessor.access(expression, AGGREGATION, Set.of(COLUMNIDENTIFIER, LITERAL)));
   }
 }

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/aggregation/GroupByConverterTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/aggregation/GroupByConverterTest.java
@@ -15,7 +15,6 @@ import org.hypertrace.entity.query.service.converter.accessor.OneOfAccessor;
 import org.hypertrace.entity.query.service.v1.ColumnIdentifier;
 import org.hypertrace.entity.query.service.v1.Expression;
 import org.hypertrace.entity.query.service.v1.Expression.ValueCase;
-import org.hypertrace.entity.query.service.v1.GroupByExpression;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,15 +28,13 @@ class GroupByConverterTest {
   @Mock private Converter<ColumnIdentifier, IdentifierExpression> identifierExpressionConverter;
   @Mock private RequestContext requestContext;
 
-  private Converter<List<GroupByExpression>, Aggregation> groupByConverter;
+  private Converter<List<Expression>, Aggregation> groupByConverter;
 
   private final ColumnIdentifier columnIdentifier =
       ColumnIdentifier.newBuilder().setColumnName("Planet_Mars").build();
   private final IdentifierExpression identifierExpression = IdentifierExpression.of("Planet_Mars");
-  private final GroupByExpression groupByExpression =
-      GroupByExpression.newBuilder()
-          .setExpression(Expression.newBuilder().setColumnIdentifier(columnIdentifier))
-          .build();
+  private final Expression expression =
+      Expression.newBuilder().setColumnIdentifier(columnIdentifier).build();
 
   @BeforeEach
   void setup() throws ConversionException {
@@ -51,6 +48,6 @@ class GroupByConverterTest {
   @Test
   void testConvert() throws ConversionException {
     Aggregation expected = Aggregation.builder().expression(identifierExpression).build();
-    assertEquals(expected, groupByConverter.convert(List.of(groupByExpression), requestContext));
+    assertEquals(expected, groupByConverter.convert(List.of(expression), requestContext));
   }
 }

--- a/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityQueryServiceTest.java
+++ b/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityQueryServiceTest.java
@@ -2,7 +2,6 @@ package org.hypertrace.entity.service.service;
 
 import static java.util.stream.Collectors.toUnmodifiableMap;
 import static org.hypertrace.entity.constants.v1.ServiceAttribute.SERVICE_ATTRIBUTE_SERVICE_TYPE;
-import static org.hypertrace.entity.query.service.v1.AggregationOperator.AGGREGATION_OPERATOR_COUNT;
 import static org.hypertrace.entity.query.service.v1.SortOrder.ASC;
 import static org.hypertrace.entity.query.service.v1.ValueType.STRING;
 import static org.hypertrace.entity.query.service.v1.ValueType.STRING_ARRAY;
@@ -69,7 +68,6 @@ import org.hypertrace.entity.query.service.v1.EntityQueryServiceGrpc.EntityQuery
 import org.hypertrace.entity.query.service.v1.Expression;
 import org.hypertrace.entity.query.service.v1.Filter;
 import org.hypertrace.entity.query.service.v1.Function;
-import org.hypertrace.entity.query.service.v1.GroupByExpression;
 import org.hypertrace.entity.query.service.v1.LiteralConstant;
 import org.hypertrace.entity.query.service.v1.Operator;
 import org.hypertrace.entity.query.service.v1.OrderByExpression;
@@ -1028,11 +1026,9 @@ public class EntityQueryServiceTest {
                                         ColumnIdentifier.newBuilder()
                                             .setColumnName(SERVICE_ID_ATTR)))))
             .addGroupBy(
-                GroupByExpression.newBuilder()
-                    .setExpression(
-                        Expression.newBuilder()
-                            .setColumnIdentifier(
-                                ColumnIdentifier.newBuilder().setColumnName(SERVICE_TYPE_ATTR))))
+                Expression.newBuilder()
+                    .setColumnIdentifier(
+                        ColumnIdentifier.newBuilder().setColumnName(SERVICE_TYPE_ATTR)))
             .addOrderBy(
                 OrderByExpression.newBuilder()
                     .setOrder(ASC)
@@ -1085,9 +1081,7 @@ public class EntityQueryServiceTest {
         ResultSetMetadata.newBuilder()
             .addColumnMetadata(ColumnMetadata.newBuilder().setColumnName(SERVICE_TYPE_ATTR).build())
             .addColumnMetadata(
-                ColumnMetadata.newBuilder()
-                    .setColumnName(AGGREGATION_OPERATOR_COUNT.name() + "_" + SERVICE_ID_ATTR)
-                    .build())
+                ColumnMetadata.newBuilder().setColumnName("COUNT_" + SERVICE_ID_ATTR).build())
             .build();
 
     // verify metadata sent for each chunk


### PR DESCRIPTION
* Removed the reduandant AggregateExpression proto
* Unwrapped GroupByExpression to directly use Expression

## Description


<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
* Unit and integration tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
