### PR TITLE
Multi value attribute grouping support

### DIFF
--- a/entity-service-impl/build.gradle.kts
+++ b/entity-service-impl/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
   annotationProcessor("org.projectlombok:lombok:1.18.22")
   compileOnly("org.projectlombok:lombok:1.18.18")
 
-  implementation("org.hypertrace.core.documentstore:document-store:0.6.12")
+  implementation("org.hypertrace.core.documentstore:document-store:0.6.13")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.7.0")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.7.0")
   implementation("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.12.3")

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/ConverterModule.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/ConverterModule.java
@@ -6,6 +6,7 @@ import com.google.inject.TypeLiteral;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import org.hypertrace.core.documentstore.expression.impl.ConstantExpression;
+import org.hypertrace.core.documentstore.expression.type.FromTypeExpression;
 import org.hypertrace.core.documentstore.query.Query;
 import org.hypertrace.core.documentstore.query.Sort;
 import org.hypertrace.entity.query.service.EntityAttributeMapping;
@@ -16,6 +17,7 @@ import org.hypertrace.entity.query.service.converter.identifier.IdentifierModule
 import org.hypertrace.entity.query.service.converter.response.ResponseModule;
 import org.hypertrace.entity.query.service.converter.selection.SelectionConverterModule;
 import org.hypertrace.entity.query.service.v1.EntityQueryRequest;
+import org.hypertrace.entity.query.service.v1.Expression;
 import org.hypertrace.entity.query.service.v1.LiteralConstant;
 import org.hypertrace.entity.query.service.v1.OrderByExpression;
 
@@ -36,6 +38,7 @@ public class ConverterModule extends AbstractModule {
         .to(ConstantExpressionConverter.class);
     bind(new TypeLiteral<Converter<List<OrderByExpression>, Sort>>() {}).to(OrderByConverter.class);
     bind(new TypeLiteral<Converter<EntityQueryRequest, Query>>() {}).to(QueryConverter.class);
+    bind(new TypeLiteral<Converter<List<Expression>, List<FromTypeExpression>>>() {}).to(FromClauseConverter.class);
   }
 
   @Provides

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/ConverterModule.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/ConverterModule.java
@@ -38,7 +38,8 @@ public class ConverterModule extends AbstractModule {
         .to(ConstantExpressionConverter.class);
     bind(new TypeLiteral<Converter<List<OrderByExpression>, Sort>>() {}).to(OrderByConverter.class);
     bind(new TypeLiteral<Converter<EntityQueryRequest, Query>>() {}).to(QueryConverter.class);
-    bind(new TypeLiteral<Converter<List<Expression>, List<FromTypeExpression>>>() {}).to(FromClauseConverter.class);
+    bind(new TypeLiteral<Converter<List<Expression>, List<FromTypeExpression>>>() {})
+        .to(FromClauseConverter.class);
   }
 
   @Provides

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/FromClauseConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/FromClauseConverter.java
@@ -1,10 +1,11 @@
 package org.hypertrace.entity.query.service.converter;
 
-import static java.util.Collections.unmodifiableList;
 import static java.util.Optional.empty;
+import static java.util.stream.Collectors.toUnmodifiableList;
 import static org.hypertrace.entity.query.service.v1.Expression.ValueCase.COLUMNIDENTIFIER;
+import static org.hypertrace.entity.query.service.v1.Expression.ValueCase.FUNCTION;
 
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -16,39 +17,52 @@ import org.hypertrace.core.documentstore.expression.type.FromTypeExpression;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.entity.query.service.EntityAttributeMapping;
 import org.hypertrace.entity.query.service.converter.accessor.OneOfAccessor;
+import org.hypertrace.entity.query.service.converter.aggregation.AggregationColumnProvider;
 import org.hypertrace.entity.query.service.v1.ColumnIdentifier;
 import org.hypertrace.entity.query.service.v1.Expression;
 import org.hypertrace.entity.query.service.v1.Expression.ValueCase;
+import org.hypertrace.entity.query.service.v1.Function;
 
 @AllArgsConstructor(onConstructor_ = {@Inject})
 public class FromClauseConverter implements Converter<List<Expression>, List<FromTypeExpression>> {
   private final OneOfAccessor<Expression, ValueCase> expressionAccessor;
   private final Converter<ColumnIdentifier, IdentifierExpression> identifierExpressionConverter;
   private final EntityAttributeMapping entityAttributeMapping;
+  private final AggregationColumnProvider aggregationColumnProvider;
 
   @Override
-  public List<FromTypeExpression> convert(final List<Expression> groupBys, final RequestContext requestContext)
+  public List<FromTypeExpression> convert(
+      final List<Expression> expressions, final RequestContext requestContext)
       throws ConversionException {
-    final List<FromTypeExpression> list = new ArrayList<>();
+    final Set<FromTypeExpression> set = new HashSet<>();
 
-    for (final Expression groupBy : groupBys) {
-      final Optional<FromTypeExpression> optionalExpression = convert(groupBy, requestContext);
-      optionalExpression.ifPresent(list::add);
+    for (final Expression expression : expressions) {
+      final Optional<FromTypeExpression> optionalExpression = convert(expression, requestContext);
+      optionalExpression.ifPresent(set::add);
     }
 
-    return unmodifiableList(list);
+    return set.stream().collect(toUnmodifiableList());
   }
 
-  private Optional<FromTypeExpression> convert(final Expression groupBy, final RequestContext requestContext)
-      throws ConversionException {
-    final ColumnIdentifier identifier =
-        expressionAccessor.access(groupBy, groupBy.getValueCase(), Set.of(COLUMNIDENTIFIER));
+  private Optional<FromTypeExpression> convert(
+      final Expression expression, final RequestContext requestContext) throws ConversionException {
+    final ColumnIdentifier identifier;
+
+    if (expression.getValueCase() == FUNCTION) {
+      final Function aggregation = expressionAccessor.access(expression, FUNCTION);
+      identifier = aggregationColumnProvider.getColumnIdentifier(aggregation);
+    } else {
+      identifier =
+          expressionAccessor.access(
+              expression, expression.getValueCase(), Set.of(COLUMNIDENTIFIER));
+    }
 
     if (!entityAttributeMapping.isMultiValued(requestContext, identifier.getColumnName())) {
       return empty();
     }
 
-    final IdentifierExpression identifierExpression = identifierExpressionConverter.convert(identifier, requestContext);
+    final IdentifierExpression identifierExpression =
+        identifierExpressionConverter.convert(identifier, requestContext);
     final FromTypeExpression fromTypeExpression = UnnestExpression.of(identifierExpression, false);
 
     return Optional.of(fromTypeExpression);

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/FromClauseConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/FromClauseConverter.java
@@ -1,0 +1,56 @@
+package org.hypertrace.entity.query.service.converter;
+
+import static java.util.Collections.unmodifiableList;
+import static java.util.Optional.empty;
+import static org.hypertrace.entity.query.service.v1.Expression.ValueCase.COLUMNIDENTIFIER;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import javax.inject.Inject;
+import lombok.AllArgsConstructor;
+import org.hypertrace.core.documentstore.expression.impl.IdentifierExpression;
+import org.hypertrace.core.documentstore.expression.impl.UnnestExpression;
+import org.hypertrace.core.documentstore.expression.type.FromTypeExpression;
+import org.hypertrace.core.grpcutils.context.RequestContext;
+import org.hypertrace.entity.query.service.EntityAttributeMapping;
+import org.hypertrace.entity.query.service.converter.accessor.OneOfAccessor;
+import org.hypertrace.entity.query.service.v1.ColumnIdentifier;
+import org.hypertrace.entity.query.service.v1.Expression;
+import org.hypertrace.entity.query.service.v1.Expression.ValueCase;
+
+@AllArgsConstructor(onConstructor_ = {@Inject})
+public class FromClauseConverter implements Converter<List<Expression>, List<FromTypeExpression>> {
+  private final OneOfAccessor<Expression, ValueCase> expressionAccessor;
+  private final Converter<ColumnIdentifier, IdentifierExpression> identifierExpressionConverter;
+  private final EntityAttributeMapping entityAttributeMapping;
+
+  @Override
+  public List<FromTypeExpression> convert(final List<Expression> groupBys, final RequestContext requestContext)
+      throws ConversionException {
+    final List<FromTypeExpression> list = new ArrayList<>();
+
+    for (final Expression groupBy : groupBys) {
+      final Optional<FromTypeExpression> optionalExpression = convert(groupBy, requestContext);
+      optionalExpression.ifPresent(list::add);
+    }
+
+    return unmodifiableList(list);
+  }
+
+  private Optional<FromTypeExpression> convert(final Expression groupBy, final RequestContext requestContext)
+      throws ConversionException {
+    final ColumnIdentifier identifier =
+        expressionAccessor.access(groupBy, groupBy.getValueCase(), Set.of(COLUMNIDENTIFIER));
+
+    if (!entityAttributeMapping.isMultiValued(requestContext, identifier.getColumnName())) {
+      return empty();
+    }
+
+    final IdentifierExpression identifierExpression = identifierExpressionConverter.convert(identifier, requestContext);
+    final FromTypeExpression fromTypeExpression = UnnestExpression.of(identifierExpression, false);
+
+    return Optional.of(fromTypeExpression);
+  }
+}

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/QueryConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/QueryConverter.java
@@ -1,5 +1,8 @@
 package org.hypertrace.entity.query.service.converter;
 
+import static com.google.common.collect.Iterables.concat;
+import static com.google.common.collect.Lists.newArrayList;
+
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.util.List;
@@ -43,8 +46,13 @@ public class QueryConverter implements Converter<EntityQueryRequest, Query> {
     builder.setFilter(filter);
 
     setFieldIfNotEmpty(
+        newArrayList(concat(request.getGroupByList(), request.getSelectionList())),
+        builder::addFromClauses,
+        fromClauseConverter,
+        requestContext);
+
+    setFieldIfNotEmpty(
         request.getGroupByList(), builder::setAggregation, groupByConverter, requestContext);
-    setFieldIfNotEmpty(request.getGroupByList(), builder::addFromClauses, fromClauseConverter, requestContext);
     setFieldIfNotEmpty(
         request.getOrderByList(), builder::setSort, orderByConverter, requestContext);
 

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/QueryConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/QueryConverter.java
@@ -5,6 +5,7 @@ import com.google.inject.Singleton;
 import java.util.List;
 import java.util.function.Function;
 import lombok.AllArgsConstructor;
+import org.hypertrace.core.documentstore.expression.type.FromTypeExpression;
 import org.hypertrace.core.documentstore.query.Aggregation;
 import org.hypertrace.core.documentstore.query.Filter;
 import org.hypertrace.core.documentstore.query.Pagination;
@@ -24,6 +25,7 @@ public class QueryConverter implements Converter<EntityQueryRequest, Query> {
   private final Converter<List<Expression>, Selection> selectionConverter;
   private final Converter<EntityQueryRequest, Filter> filterConverter;
 
+  private final Converter<List<Expression>, List<FromTypeExpression>> fromClauseConverter;
   private final Converter<List<Expression>, Aggregation> groupByConverter;
 
   private final Converter<List<OrderByExpression>, Sort> orderByConverter;
@@ -42,6 +44,7 @@ public class QueryConverter implements Converter<EntityQueryRequest, Query> {
 
     setFieldIfNotEmpty(
         request.getGroupByList(), builder::setAggregation, groupByConverter, requestContext);
+    setFieldIfNotEmpty(request.getGroupByList(), builder::addFromClauses, fromClauseConverter, requestContext);
     setFieldIfNotEmpty(
         request.getOrderByList(), builder::setSort, orderByConverter, requestContext);
 

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/aggregation/AggregationAliasProvider.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/aggregation/AggregationAliasProvider.java
@@ -1,18 +1,11 @@
 package org.hypertrace.entity.query.service.converter.aggregation;
 
-import static org.hypertrace.entity.query.service.v1.Expression.ValueCase.COLUMNIDENTIFIER;
-
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import java.util.List;
-import java.util.Set;
 import lombok.AllArgsConstructor;
 import org.hypertrace.entity.query.service.converter.AliasProvider;
 import org.hypertrace.entity.query.service.converter.ConversionException;
-import org.hypertrace.entity.query.service.converter.accessor.OneOfAccessor;
 import org.hypertrace.entity.query.service.v1.ColumnIdentifier;
-import org.hypertrace.entity.query.service.v1.Expression;
-import org.hypertrace.entity.query.service.v1.Expression.ValueCase;
 import org.hypertrace.entity.query.service.v1.Function;
 import org.hypertrace.entity.service.util.StringUtils;
 
@@ -20,20 +13,12 @@ import org.hypertrace.entity.service.util.StringUtils;
 @AllArgsConstructor(onConstructor_ = {@Inject})
 public class AggregationAliasProvider implements AliasProvider<Function> {
   private final AliasProvider<ColumnIdentifier> identifierAliasProvider;
-  private final OneOfAccessor<Expression, ValueCase> expressionAccessor;
+  private final AggregationColumnProvider aggregationColumnProvider;
 
   @Override
   public String getAlias(final Function aggregateExpression) throws ConversionException {
-    final List<Expression> innerExpressions = aggregateExpression.getArgumentsList();
-
-    if (innerExpressions.size() != 1) {
-      throw new ConversionException("Aggregation function should have exactly one argument");
-    }
-
-    final Expression innerExpression = innerExpressions.get(0);
     final ColumnIdentifier containingIdentifier =
-        expressionAccessor.access(
-            innerExpression, innerExpression.getValueCase(), Set.of(COLUMNIDENTIFIER));
+        aggregationColumnProvider.getColumnIdentifier(aggregateExpression);
     final String alias = aggregateExpression.getAlias();
 
     if (StringUtils.isNotBlank(alias)) {

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/aggregation/AggregationAliasProvider.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/aggregation/AggregationAliasProvider.java
@@ -1,11 +1,17 @@
 package org.hypertrace.entity.query.service.converter.aggregation;
 
+import static org.hypertrace.entity.query.service.v1.Expression.ValueCase.COLUMNIDENTIFIER;
+
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import org.hypertrace.entity.query.service.converter.AliasProvider;
 import org.hypertrace.entity.query.service.converter.ConversionException;
+import org.hypertrace.entity.query.service.converter.accessor.OneOfAccessor;
 import org.hypertrace.entity.query.service.v1.ColumnIdentifier;
+import org.hypertrace.entity.query.service.v1.Expression;
+import org.hypertrace.entity.query.service.v1.Expression.ValueCase;
 import org.hypertrace.entity.query.service.v1.Function;
 import org.hypertrace.entity.service.util.StringUtils;
 
@@ -14,11 +20,14 @@ import org.hypertrace.entity.service.util.StringUtils;
 public class AggregationAliasProvider implements AliasProvider<Function> {
   private final AliasProvider<ColumnIdentifier> identifierAliasProvider;
   private final AggregationColumnProvider aggregationColumnProvider;
+  private final OneOfAccessor<Expression, ValueCase> expressionAccessor;
 
   @Override
   public String getAlias(final Function aggregateExpression) throws ConversionException {
+    final Expression expression =
+        aggregationColumnProvider.getAggregationColumn(aggregateExpression);
     final ColumnIdentifier containingIdentifier =
-        aggregationColumnProvider.getColumnIdentifier(aggregateExpression);
+        expressionAccessor.access(expression, expression.getValueCase(), Set.of(COLUMNIDENTIFIER));
     final String alias = aggregateExpression.getAlias();
 
     if (StringUtils.isNotBlank(alias)) {

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/aggregation/AggregationColumnProvider.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/aggregation/AggregationColumnProvider.java
@@ -1,0 +1,33 @@
+package org.hypertrace.entity.query.service.converter.aggregation;
+
+import static org.hypertrace.entity.query.service.v1.Expression.ValueCase.COLUMNIDENTIFIER;
+
+import java.util.List;
+import java.util.Set;
+import javax.inject.Inject;
+import lombok.AllArgsConstructor;
+import org.hypertrace.entity.query.service.converter.ConversionException;
+import org.hypertrace.entity.query.service.converter.accessor.OneOfAccessor;
+import org.hypertrace.entity.query.service.v1.ColumnIdentifier;
+import org.hypertrace.entity.query.service.v1.Expression;
+import org.hypertrace.entity.query.service.v1.Expression.ValueCase;
+import org.hypertrace.entity.query.service.v1.Function;
+
+@AllArgsConstructor(onConstructor_ = {@Inject})
+public class AggregationColumnProvider {
+  private final OneOfAccessor<Expression, ValueCase> expressionAccessor;
+
+  public final ColumnIdentifier getColumnIdentifier(final Function function)
+      throws ConversionException {
+    final List<Expression> innerExpressions = function.getArgumentsList();
+
+    if (innerExpressions.size() != 1) {
+      throw new ConversionException("Aggregation function should have exactly one argument");
+    }
+
+    final Expression innerExpression = innerExpressions.get(0);
+
+    return expressionAccessor.access(
+        innerExpression, innerExpression.getValueCase(), Set.of(COLUMNIDENTIFIER));
+  }
+}

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/aggregation/AggregationColumnProvider.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/aggregation/AggregationColumnProvider.java
@@ -1,33 +1,19 @@
 package org.hypertrace.entity.query.service.converter.aggregation;
 
-import static org.hypertrace.entity.query.service.v1.Expression.ValueCase.COLUMNIDENTIFIER;
-
 import java.util.List;
-import java.util.Set;
-import javax.inject.Inject;
-import lombok.AllArgsConstructor;
 import org.hypertrace.entity.query.service.converter.ConversionException;
-import org.hypertrace.entity.query.service.converter.accessor.OneOfAccessor;
-import org.hypertrace.entity.query.service.v1.ColumnIdentifier;
 import org.hypertrace.entity.query.service.v1.Expression;
-import org.hypertrace.entity.query.service.v1.Expression.ValueCase;
 import org.hypertrace.entity.query.service.v1.Function;
 
-@AllArgsConstructor(onConstructor_ = {@Inject})
 public class AggregationColumnProvider {
-  private final OneOfAccessor<Expression, ValueCase> expressionAccessor;
 
-  public final ColumnIdentifier getColumnIdentifier(final Function function)
-      throws ConversionException {
+  public final Expression getAggregationColumn(final Function function) throws ConversionException {
     final List<Expression> innerExpressions = function.getArgumentsList();
 
     if (innerExpressions.size() != 1) {
       throw new ConversionException("Aggregation function should have exactly one argument");
     }
 
-    final Expression innerExpression = innerExpressions.get(0);
-
-    return expressionAccessor.access(
-        innerExpression, innerExpression.getValueCase(), Set.of(COLUMNIDENTIFIER));
+    return innerExpressions.get(0);
   }
 }

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/identifier/ArrayElementSuffixAddingIdentifierConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/identifier/ArrayElementSuffixAddingIdentifierConverter.java
@@ -1,12 +1,14 @@
 package org.hypertrace.entity.query.service.converter.identifier;
 
+import static org.hypertrace.entity.query.service.converter.ValueHelper.VALUES_KEY;
+import static org.hypertrace.entity.query.service.converter.ValueHelper.VALUE_KEY;
 import static org.hypertrace.entity.query.service.converter.ValueHelper.VALUE_LIST_KEY;
 import static org.hypertrace.entity.query.service.converter.filter.FilteringExpressionConverterBase.ARRAY_OPERATORS;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import org.hypertrace.entity.query.service.converter.ConversionException;
 import org.hypertrace.entity.query.service.converter.ValueHelper;
-import org.hypertrace.entity.query.service.v1.Operator;
 
 /**
  * Adds suffix .valueList.values.%d.value.&lt;type&gt; for element-by-element comparison.
@@ -15,7 +17,8 @@ import org.hypertrace.entity.query.service.v1.Operator;
  */
 @Singleton
 public class ArrayElementSuffixAddingIdentifierConverter extends SuffixAddingIdentifierConverter {
-  private static final String ARRAY_ELEMENT_SUFFIX = "." + VALUE_LIST_KEY + ".values.%d.value.";
+  private static final String ARRAY_ELEMENT_SUFFIX =
+      "." + VALUE_LIST_KEY + "." + VALUES_KEY + ".%d." + VALUE_KEY + ".";
   private final ArraySuffixAddingIdentifierConverter arraySuffixAddingIdentifierConverter;
 
   @Inject
@@ -27,12 +30,13 @@ public class ArrayElementSuffixAddingIdentifierConverter extends SuffixAddingIde
   }
 
   @Override
-  protected String getSuffix(final Operator operator) {
-    if (ARRAY_OPERATORS.contains(operator)) {
+  protected String getSuffix(final IdentifierConversionMetadata metadata)
+      throws ConversionException {
+    if (ARRAY_OPERATORS.contains(metadata.getOperator())) {
       // If the operator is an array operator, fall-back to array suffix
-      return arraySuffixAddingIdentifierConverter.getSuffix(operator);
+      return arraySuffixAddingIdentifierConverter.getSuffix(metadata);
     }
 
-    return ARRAY_ELEMENT_SUFFIX;
+    return ARRAY_ELEMENT_SUFFIX + getTypeName(metadata);
   }
 }

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/identifier/ArrayPathSuffixAddingIdentifierConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/identifier/ArrayPathSuffixAddingIdentifierConverter.java
@@ -1,0 +1,24 @@
+package org.hypertrace.entity.query.service.converter.identifier;
+
+import static org.hypertrace.entity.query.service.converter.ValueHelper.VALUES_KEY;
+import static org.hypertrace.entity.query.service.converter.ValueHelper.VALUE_LIST_KEY;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.hypertrace.entity.query.service.converter.ValueHelper;
+
+/** Adds suffix .valueList.values for unwinding */
+@Singleton
+public class ArrayPathSuffixAddingIdentifierConverter extends SuffixAddingIdentifierConverter {
+  private static final String ARRAY_PATH_SUFFIX = "." + VALUE_LIST_KEY + "." + VALUES_KEY;
+
+  @Inject
+  public ArrayPathSuffixAddingIdentifierConverter(final ValueHelper valueHelper) {
+    super(valueHelper);
+  }
+
+  @Override
+  protected String getSuffix(final IdentifierConversionMetadata metadata) {
+    return ARRAY_PATH_SUFFIX;
+  }
+}

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/identifier/ArraySuffixAddingIdentifierConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/identifier/ArraySuffixAddingIdentifierConverter.java
@@ -1,16 +1,19 @@
 package org.hypertrace.entity.query.service.converter.identifier;
 
+import static org.hypertrace.entity.query.service.converter.ValueHelper.VALUES_KEY;
+import static org.hypertrace.entity.query.service.converter.ValueHelper.VALUE_KEY;
 import static org.hypertrace.entity.query.service.converter.ValueHelper.VALUE_LIST_KEY;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import org.hypertrace.entity.query.service.converter.ConversionException;
 import org.hypertrace.entity.query.service.converter.ValueHelper;
-import org.hypertrace.entity.query.service.v1.Operator;
 
 /** Adds suffix .valueList.values.value.&lt;type&gt; for direct comparison */
 @Singleton
 public class ArraySuffixAddingIdentifierConverter extends SuffixAddingIdentifierConverter {
-  private static final String ARRAY_SUFFIX = "." + VALUE_LIST_KEY + ".values.value.";
+  private static final String ARRAY_SUFFIX =
+      "." + VALUE_LIST_KEY + "." + VALUES_KEY + "." + VALUE_KEY + ".";
 
   @Inject
   public ArraySuffixAddingIdentifierConverter(final ValueHelper valueHelper) {
@@ -18,7 +21,8 @@ public class ArraySuffixAddingIdentifierConverter extends SuffixAddingIdentifier
   }
 
   @Override
-  protected String getSuffix(final Operator operator) {
-    return ARRAY_SUFFIX;
+  protected String getSuffix(final IdentifierConversionMetadata metadata)
+      throws ConversionException {
+    return ARRAY_SUFFIX + getTypeName(metadata);
   }
 }

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/identifier/MapSuffixAddingIdentifierConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/identifier/MapSuffixAddingIdentifierConverter.java
@@ -1,11 +1,13 @@
 package org.hypertrace.entity.query.service.converter.identifier;
 
+import static org.hypertrace.entity.query.service.converter.ValueHelper.VALUES_KEY;
+import static org.hypertrace.entity.query.service.converter.ValueHelper.VALUE_KEY;
 import static org.hypertrace.entity.query.service.converter.ValueHelper.VALUE_MAP_KEY;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import org.hypertrace.entity.query.service.converter.ConversionException;
 import org.hypertrace.entity.query.service.converter.ValueHelper;
-import org.hypertrace.entity.query.service.v1.Operator;
 
 /**
  * Adds suffix .valueMap.values.%s.value.&lt;type&gt; for element-by-element comparison.
@@ -14,7 +16,8 @@ import org.hypertrace.entity.query.service.v1.Operator;
  */
 @Singleton
 public class MapSuffixAddingIdentifierConverter extends SuffixAddingIdentifierConverter {
-  private static final String SUFFIX = "." + VALUE_MAP_KEY + ".values.%s.value.";
+  private static final String SUFFIX =
+      "." + VALUE_MAP_KEY + "." + VALUES_KEY + ".%s." + VALUE_KEY + ".";
 
   @Inject
   public MapSuffixAddingIdentifierConverter(final ValueHelper valueHelper) {
@@ -22,7 +25,8 @@ public class MapSuffixAddingIdentifierConverter extends SuffixAddingIdentifierCo
   }
 
   @Override
-  protected String getSuffix(final Operator operator) {
-    return SUFFIX;
+  protected String getSuffix(final IdentifierConversionMetadata metadata)
+      throws ConversionException {
+    return SUFFIX + getTypeName(metadata);
   }
 }

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/identifier/PrimitiveSuffixAddingIdentifierConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/identifier/PrimitiveSuffixAddingIdentifierConverter.java
@@ -1,14 +1,16 @@
 package org.hypertrace.entity.query.service.converter.identifier;
 
+import static org.hypertrace.entity.query.service.converter.ValueHelper.VALUE_KEY;
+
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import org.hypertrace.entity.query.service.converter.ConversionException;
 import org.hypertrace.entity.query.service.converter.ValueHelper;
-import org.hypertrace.entity.query.service.v1.Operator;
 
 /** Adds suffix value.&lt;type&gt; for direct comparison. */
 @Singleton
 public class PrimitiveSuffixAddingIdentifierConverter extends SuffixAddingIdentifierConverter {
-  private static final String SUFFIX = ".value.";
+  private static final String SUFFIX = "." + VALUE_KEY + ".";
 
   @Inject
   public PrimitiveSuffixAddingIdentifierConverter(final ValueHelper valueHelper) {
@@ -16,7 +18,8 @@ public class PrimitiveSuffixAddingIdentifierConverter extends SuffixAddingIdenti
   }
 
   @Override
-  protected String getSuffix(final Operator operator) {
-    return SUFFIX;
+  protected String getSuffix(final IdentifierConversionMetadata metadata)
+      throws ConversionException {
+    return SUFFIX + getTypeName(metadata);
   }
 }

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/identifier/SuffixAddingIdentifierConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/identifier/SuffixAddingIdentifierConverter.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.entity.query.service.converter.ConversionException;
 import org.hypertrace.entity.query.service.converter.ValueHelper;
-import org.hypertrace.entity.query.service.v1.Operator;
 
 @AllArgsConstructor
 public abstract class SuffixAddingIdentifierConverter extends IdentifierConverter {
@@ -15,11 +14,16 @@ public abstract class SuffixAddingIdentifierConverter extends IdentifierConverte
       final IdentifierConversionMetadata metadata, final RequestContext requestContext)
       throws ConversionException {
     final String subDocPath = metadata.getSubDocPath();
-    final String suffix = getSuffix(metadata.getOperator());
-    final String typeSuffix = valueHelper.getStringValue(metadata.getValueType());
+    final String suffix = getSuffix(metadata);
 
-    return subDocPath + suffix + typeSuffix;
+    return subDocPath + suffix;
   }
 
-  protected abstract String getSuffix(final Operator operator);
+  protected final String getTypeName(final IdentifierConversionMetadata metadata)
+      throws ConversionException {
+    return valueHelper.getStringValue(metadata.getValueType());
+  }
+
+  protected abstract String getSuffix(final IdentifierConversionMetadata metadata)
+      throws ConversionException;
 }

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/FromClauseConverterTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/FromClauseConverterTest.java
@@ -1,0 +1,99 @@
+package org.hypertrace.entity.query.service.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.hypertrace.core.documentstore.expression.impl.IdentifierExpression;
+import org.hypertrace.core.documentstore.expression.impl.UnnestExpression;
+import org.hypertrace.core.documentstore.expression.type.FromTypeExpression;
+import org.hypertrace.core.grpcutils.context.RequestContext;
+import org.hypertrace.entity.query.service.EntityAttributeMapping;
+import org.hypertrace.entity.query.service.converter.accessor.ExpressionOneOfAccessor;
+import org.hypertrace.entity.query.service.converter.aggregation.AggregationColumnProvider;
+import org.hypertrace.entity.query.service.v1.ColumnIdentifier;
+import org.hypertrace.entity.query.service.v1.Expression;
+import org.hypertrace.entity.query.service.v1.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FromClauseConverterTest {
+
+  @Mock private Converter<ColumnIdentifier, IdentifierExpression> mockIdentifierExpressionConverter;
+  @Mock private EntityAttributeMapping mockEntityAttributeMapping;
+
+  private Converter<List<Expression>, List<FromTypeExpression>> fromClauseConverter;
+
+  @BeforeEach
+  void setUp() {
+    final ExpressionOneOfAccessor expressionOneOfAccessor = new ExpressionOneOfAccessor();
+    fromClauseConverter =
+        new FromClauseConverter(
+            expressionOneOfAccessor,
+            mockIdentifierExpressionConverter,
+            mockEntityAttributeMapping,
+            new AggregationColumnProvider(expressionOneOfAccessor));
+  }
+
+  @Test
+  void testConvert1() throws Exception {
+    final ColumnIdentifier col1 = ColumnIdentifier.newBuilder().setColumnName("col1").build();
+
+    final ColumnIdentifier col2 = ColumnIdentifier.newBuilder().setColumnName("col2").build();
+
+    final List<Expression> expressions =
+        List.of(
+            Expression.newBuilder().setColumnIdentifier(col1).build(),
+            Expression.newBuilder()
+                .setFunction(
+                    Function.newBuilder()
+                        .addArguments(Expression.newBuilder().setColumnIdentifier(col2)))
+                .build());
+
+    final RequestContext requestContext = new RequestContext();
+    when(mockEntityAttributeMapping.isMultiValued(eq(requestContext), eq("col1")))
+        .thenReturn(false);
+    when(mockEntityAttributeMapping.isMultiValued(eq(requestContext), eq("col2"))).thenReturn(true);
+    when(mockIdentifierExpressionConverter.convert(col2, requestContext))
+        .thenReturn(IdentifierExpression.of("name"));
+
+    final List<FromTypeExpression> expected =
+        List.of(UnnestExpression.of(IdentifierExpression.of("name"), false));
+    final List<FromTypeExpression> actual =
+        fromClauseConverter.convert(expressions, requestContext);
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testConvert1_ConverterThrowsConversionException() throws Exception {
+    final ColumnIdentifier col1 = ColumnIdentifier.newBuilder().setColumnName("col1").build();
+
+    final ColumnIdentifier col2 = ColumnIdentifier.newBuilder().setColumnName("col2").build();
+
+    final List<Expression> expressions =
+        List.of(
+            Expression.newBuilder().setColumnIdentifier(col1).build(),
+            Expression.newBuilder()
+                .setFunction(
+                    Function.newBuilder()
+                        .addArguments(Expression.newBuilder().setColumnIdentifier(col2)))
+                .build());
+
+    final RequestContext requestContext = new RequestContext();
+    when(mockEntityAttributeMapping.isMultiValued(eq(requestContext), eq("col1")))
+        .thenReturn(false);
+    when(mockEntityAttributeMapping.isMultiValued(eq(requestContext), eq("col2"))).thenReturn(true);
+    when(mockIdentifierExpressionConverter.convert(col2, requestContext))
+        .thenThrow(ConversionException.class);
+
+    assertThrows(
+        ConversionException.class, () -> fromClauseConverter.convert(expressions, requestContext));
+  }
+}

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/FromClauseConverterTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/FromClauseConverterTest.java
@@ -12,7 +12,6 @@ import org.hypertrace.core.documentstore.expression.type.FromTypeExpression;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.entity.query.service.EntityAttributeMapping;
 import org.hypertrace.entity.query.service.converter.accessor.ExpressionOneOfAccessor;
-import org.hypertrace.entity.query.service.converter.aggregation.AggregationColumnProvider;
 import org.hypertrace.entity.query.service.v1.ColumnIdentifier;
 import org.hypertrace.entity.query.service.v1.Expression;
 import org.hypertrace.entity.query.service.v1.Function;
@@ -35,10 +34,7 @@ class FromClauseConverterTest {
     final ExpressionOneOfAccessor expressionOneOfAccessor = new ExpressionOneOfAccessor();
     fromClauseConverter =
         new FromClauseConverter(
-            expressionOneOfAccessor,
-            mockIdentifierExpressionConverter,
-            mockEntityAttributeMapping,
-            new AggregationColumnProvider(expressionOneOfAccessor));
+            expressionOneOfAccessor, mockIdentifierExpressionConverter, mockEntityAttributeMapping);
   }
 
   @Test
@@ -50,11 +46,7 @@ class FromClauseConverterTest {
     final List<Expression> expressions =
         List.of(
             Expression.newBuilder().setColumnIdentifier(col1).build(),
-            Expression.newBuilder()
-                .setFunction(
-                    Function.newBuilder()
-                        .addArguments(Expression.newBuilder().setColumnIdentifier(col2)))
-                .build());
+            Expression.newBuilder().setColumnIdentifier(col2).build());
 
     final RequestContext requestContext = new RequestContext();
     when(mockEntityAttributeMapping.isMultiValued(eq(requestContext), eq("col1")))
@@ -72,9 +64,8 @@ class FromClauseConverterTest {
   }
 
   @Test
-  void testConvert1_ConverterThrowsConversionException() throws Exception {
+  void testConvert1_ConverterThrowsConversionException() {
     final ColumnIdentifier col1 = ColumnIdentifier.newBuilder().setColumnName("col1").build();
-
     final ColumnIdentifier col2 = ColumnIdentifier.newBuilder().setColumnName("col2").build();
 
     final List<Expression> expressions =
@@ -87,11 +78,6 @@ class FromClauseConverterTest {
                 .build());
 
     final RequestContext requestContext = new RequestContext();
-    when(mockEntityAttributeMapping.isMultiValued(eq(requestContext), eq("col1")))
-        .thenReturn(false);
-    when(mockEntityAttributeMapping.isMultiValued(eq(requestContext), eq("col2"))).thenReturn(true);
-    when(mockIdentifierExpressionConverter.convert(col2, requestContext))
-        .thenThrow(ConversionException.class);
 
     assertThrows(
         ConversionException.class, () -> fromClauseConverter.convert(expressions, requestContext));

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/aggregation/AggregationAliasProviderTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/aggregation/AggregationAliasProviderTest.java
@@ -35,7 +35,8 @@ class AggregationAliasProviderTest {
     columnIdentifierBuilder = ColumnIdentifier.newBuilder().setColumnName("Welcome_Mars");
 
     aggregationAliasProvider =
-        new AggregationAliasProvider(identifierAliasProvider, expressionAccessor);
+        new AggregationAliasProvider(
+            identifierAliasProvider, new AggregationColumnProvider(expressionAccessor));
     aggregateExpressionBuilder =
         Function.newBuilder()
             .addArguments(Expression.newBuilder().setColumnIdentifier(columnIdentifierBuilder));

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/aggregation/AggregationAliasProviderTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/aggregation/AggregationAliasProviderTest.java
@@ -36,7 +36,7 @@ class AggregationAliasProviderTest {
 
     aggregationAliasProvider =
         new AggregationAliasProvider(
-            identifierAliasProvider, new AggregationColumnProvider(expressionAccessor));
+            identifierAliasProvider, new AggregationColumnProvider(), expressionAccessor);
     aggregateExpressionBuilder =
         Function.newBuilder()
             .addArguments(Expression.newBuilder().setColumnIdentifier(columnIdentifierBuilder));

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/aggregation/AggregationColumnProviderTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/aggregation/AggregationColumnProviderTest.java
@@ -1,0 +1,53 @@
+package org.hypertrace.entity.query.service.converter.aggregation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.hypertrace.entity.query.service.converter.ConversionException;
+import org.hypertrace.entity.query.service.converter.accessor.ExpressionOneOfAccessor;
+import org.hypertrace.entity.query.service.v1.ColumnIdentifier;
+import org.hypertrace.entity.query.service.v1.Expression;
+import org.hypertrace.entity.query.service.v1.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AggregationColumnProviderTest {
+
+  private AggregationColumnProvider aggregationColumnProvider;
+
+  @BeforeEach
+  void setUp() {
+    aggregationColumnProvider = new AggregationColumnProvider(new ExpressionOneOfAccessor());
+  }
+
+  @Test
+  void testGetColumnIdentifier() throws Exception {
+    final ColumnIdentifier col1 = ColumnIdentifier.newBuilder().setColumnName("col1").build();
+
+    final Function function =
+        Function.newBuilder()
+            .setFunctionName("DISTINCT")
+            .addArguments(Expression.newBuilder().setColumnIdentifier(col1).build())
+            .build();
+
+    final ColumnIdentifier result = aggregationColumnProvider.getColumnIdentifier(function);
+
+    assertEquals(col1, result);
+  }
+
+  @Test
+  void testGetColumnIdentifier_ThrowsConversionException() {
+    final ColumnIdentifier col1 = ColumnIdentifier.newBuilder().setColumnName("col1").build();
+    final ColumnIdentifier col2 = ColumnIdentifier.newBuilder().setColumnName("col2").build();
+
+    final Function function =
+        Function.newBuilder()
+            .setFunctionName("DISTINCT")
+            .addArguments(Expression.newBuilder().setColumnIdentifier(col1).build())
+            .addArguments(Expression.newBuilder().setColumnIdentifier(col2).build())
+            .build();
+
+    assertThrows(
+        ConversionException.class, () -> aggregationColumnProvider.getColumnIdentifier(function));
+  }
+}

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/aggregation/AggregationColumnProviderTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/aggregation/AggregationColumnProviderTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.hypertrace.entity.query.service.converter.ConversionException;
-import org.hypertrace.entity.query.service.converter.accessor.ExpressionOneOfAccessor;
 import org.hypertrace.entity.query.service.v1.ColumnIdentifier;
 import org.hypertrace.entity.query.service.v1.Expression;
 import org.hypertrace.entity.query.service.v1.Function;
@@ -17,22 +16,22 @@ class AggregationColumnProviderTest {
 
   @BeforeEach
   void setUp() {
-    aggregationColumnProvider = new AggregationColumnProvider(new ExpressionOneOfAccessor());
+    aggregationColumnProvider = new AggregationColumnProvider();
   }
 
   @Test
   void testGetColumnIdentifier() throws Exception {
-    final ColumnIdentifier col1 = ColumnIdentifier.newBuilder().setColumnName("col1").build();
-
-    final Function function =
-        Function.newBuilder()
-            .setFunctionName("DISTINCT")
-            .addArguments(Expression.newBuilder().setColumnIdentifier(col1).build())
+    final Expression exp1 =
+        Expression.newBuilder()
+            .setColumnIdentifier(ColumnIdentifier.newBuilder().setColumnName("col1"))
             .build();
 
-    final ColumnIdentifier result = aggregationColumnProvider.getColumnIdentifier(function);
+    final Function function =
+        Function.newBuilder().setFunctionName("DISTINCT").addArguments(exp1).build();
 
-    assertEquals(col1, result);
+    final Expression result = aggregationColumnProvider.getAggregationColumn(function);
+
+    assertEquals(exp1, result);
   }
 
   @Test
@@ -48,6 +47,6 @@ class AggregationColumnProviderTest {
             .build();
 
     assertThrows(
-        ConversionException.class, () -> aggregationColumnProvider.getColumnIdentifier(function));
+        ConversionException.class, () -> aggregationColumnProvider.getAggregationColumn(function));
   }
 }

--- a/entity-service/build.gradle.kts
+++ b/entity-service/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
   implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.7.0")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.7.0")
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.28")
-  implementation("org.hypertrace.core.documentstore:document-store:0.6.12")
+  implementation("org.hypertrace.core.documentstore:document-store:0.6.13")
 
   runtimeOnly("io.grpc:grpc-netty:1.43.1")
 


### PR DESCRIPTION
## Description
Aggregations and grouping can now be applied on multi-value attributes

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
