### PR TITLE
Add api-naming source attribute

### DIFF
--- a/entity-service-api/src/main/proto/org/hypertrace/entity/constants/v1/entity_attribute.proto
+++ b/entity-service-api/src/main/proto/org/hypertrace/entity/constants/v1/entity_attribute.proto
@@ -34,6 +34,7 @@ enum ApiAttribute {
   API_ATTRIBUTE_DISCOVERY_FROM = 24 [(string_value) = "api_discovery_from"];
   API_ATTRIBUTE_DISCOVERY_STATE = 25 [(string_value) = "api_discovery_state"];
   API_ATTRIBUTE_DISCOVERY_TIMESTAMP = 26 [(string_value) = "api_discovery_timestamp"];
+  API_ATTRIBUTE_NAMING_SOURCE = 27 [(string_value) = "api_naming_source"];
   reserved 5 to 17, 19 to 21;
 }
 

--- a/entity-service-api/src/main/proto/org/hypertrace/entity/constants/v1/entity_attribute.proto
+++ b/entity-service-api/src/main/proto/org/hypertrace/entity/constants/v1/entity_attribute.proto
@@ -34,7 +34,7 @@ enum ApiAttribute {
   API_ATTRIBUTE_DISCOVERY_FROM = 24 [(string_value) = "api_discovery_from"];
   API_ATTRIBUTE_DISCOVERY_STATE = 25 [(string_value) = "api_discovery_state"];
   API_ATTRIBUTE_DISCOVERY_TIMESTAMP = 26 [(string_value) = "api_discovery_timestamp"];
-  API_ATTRIBUTE_NAMING_SOURCE = 27 [(string_value) = "api_naming_source"];
+  API_ATTRIBUTE_NAME_SOURCE = 27 [(string_value) = "api_name_source"];
   reserved 5 to 17, 19 to 21;
 }
 


### PR DESCRIPTION
## Description
Added a new attribute in API-section which maintains the information that what was the source of api-discovery - Platform or Agent.

### Testing
Ran unit tests locally

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
