### PR TITLE
Fix default child filter case in LogicalExpressionConverter

### DIFF
--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/LogicalExpressionConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/LogicalExpressionConverter.java
@@ -46,15 +46,24 @@ public class LogicalExpressionConverter implements Converter<Filter, FilterTypeE
 
     final List<FilterTypeExpression> innerFilters = new ArrayList<>();
     for (final Filter innerFilter : filter.getChildFilterList()) {
+      if (Filter.getDefaultInstance().equals(innerFilter)) {
+        continue;
+      }
+
       final FilterTypeExpression expression = convertInnerFilter(innerFilter, requestContext);
       innerFilters.add(expression);
     }
 
-    if (innerFilters.size() == 1) {
-      return innerFilters.get(0);
-    }
+    switch (innerFilters.size()) {
+      case 0:
+        throw new ConversionException(String.format("All child filters are empty in: %s", filter));
 
-    return LogicalExpression.builder().operator(operator).operands(innerFilters).build();
+      case 1:
+        return innerFilters.get(0);
+
+      default:
+        return LogicalExpression.builder().operator(operator).operands(innerFilters).build();
+    }
   }
 
   private FilterTypeExpression convertInnerFilter(

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/filter/LogicalExpressionConverterTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/filter/LogicalExpressionConverterTest.java
@@ -30,8 +30,8 @@ class LogicalExpressionConverterTest {
   @Mock private FilterTypeExpression filteringExpression1;
   @Mock private FilterTypeExpression filteringExpression2;
 
-  private final Filter childFilter1 = Filter.newBuilder().setOperator(Operator.AND).build();
-  private final Filter childFilter2 = Filter.newBuilder().setOperator(Operator.OR).build();
+  private final Filter childFilter1 = Filter.newBuilder().setOperator(Operator.IN).build();
+  private final Filter childFilter2 = Filter.newBuilder().setOperator(Operator.EQ).build();
   private final Filter filter =
       Filter.newBuilder()
           .setOperator(Operator.AND)
@@ -93,6 +93,29 @@ class LogicalExpressionConverterTest {
   void testSingleChildFilter() throws ConversionException {
     Filter filter =
         Filter.newBuilder().setOperator(Operator.AND).addChildFilter(childFilter1).build();
+    assertEquals(filteringExpression1, logicalExpressionConverter.convert(filter, requestContext));
+  }
+
+  @Test
+  void testAllChildFiltersEmpty() {
+    Filter filter =
+        Filter.newBuilder()
+            .setOperator(Operator.OR)
+            .addChildFilter(Filter.getDefaultInstance())
+            .build();
+    assertThrows(
+        ConversionException.class,
+        () -> logicalExpressionConverter.convert(filter, requestContext));
+  }
+
+  @Test
+  void testFewChildFiltersEmpty() throws ConversionException {
+    Filter filter =
+        Filter.newBuilder()
+            .setOperator(Operator.OR)
+            .addChildFilter(Filter.getDefaultInstance())
+            .addChildFilter(childFilter1)
+            .build();
     assertEquals(filteringExpression1, logicalExpressionConverter.convert(filter, requestContext));
   }
 }


### PR DESCRIPTION
## Description
Default child filter case is handled

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Added unit tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
