### PR TITLE
chore: add DISTINCT_ARRAY operator

### DIFF
--- a/entity-service-impl/build.gradle.kts
+++ b/entity-service-impl/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
   annotationProcessor("org.projectlombok:lombok:1.18.22")
   compileOnly("org.projectlombok:lombok:1.18.18")
 
-  implementation("org.hypertrace.core.documentstore:document-store:0.7.8")
+  implementation("org.hypertrace.core.documentstore:document-store:0.7.9")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.7.3")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.7.3")
   implementation("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.12.3")

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/aggregation/AggregateExpressionConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/aggregation/AggregateExpressionConverter.java
@@ -79,6 +79,8 @@ public class AggregateExpressionConverter implements Converter<Function, Aggrega
     map.put("SUM", SUM);
     map.put("COUNT", COUNT);
     map.put("DISTINCTCOUNT", DISTINCT_COUNT);
+    // Note: The usage of DISTINCT is deprecated and would be removed once the upstream services are
+    // migrated
     map.put("DISTINCT", DISTINCT_ARRAY);
     map.put("DISTINCT_ARRAY", DISTINCT_ARRAY);
 

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/aggregation/AggregateExpressionConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/aggregation/AggregateExpressionConverter.java
@@ -4,7 +4,7 @@ import static com.google.common.base.Suppliers.memoize;
 import static java.util.Collections.unmodifiableMap;
 import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.AVG;
 import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.COUNT;
-import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.DISTINCT;
+import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.DISTINCT_ARRAY;
 import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.DISTINCT_COUNT;
 import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.MAX;
 import static org.hypertrace.core.documentstore.expression.operators.AggregationOperator.MIN;
@@ -79,7 +79,8 @@ public class AggregateExpressionConverter implements Converter<Function, Aggrega
     map.put("SUM", SUM);
     map.put("COUNT", COUNT);
     map.put("DISTINCTCOUNT", DISTINCT_COUNT);
-    map.put("DISTINCT", DISTINCT);
+    map.put("DISTINCT", DISTINCT_ARRAY);
+    map.put("DISTINCT_ARRAY", DISTINCT_ARRAY);
 
     return unmodifiableMap(map);
   }

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/aggregation/AggregationAliasProviderTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/aggregation/AggregationAliasProviderTest.java
@@ -47,15 +47,15 @@ class AggregationAliasProviderTest {
 
   @Test
   void testGetAlias() throws ConversionException {
-    Function expression = aggregateExpressionBuilder.setFunctionName("DISTINCT").build();
-    assertEquals("DISTINCT_Welcome_Mars", aggregationAliasProvider.getAlias(expression));
+    Function expression = aggregateExpressionBuilder.setFunctionName("DISTINCT_ARRAY").build();
+    assertEquals("DISTINCT_ARRAY_Welcome_Mars", aggregationAliasProvider.getAlias(expression));
   }
 
   @Test
   void testGetSetAlias() throws ConversionException {
     Function expression =
         aggregateExpressionBuilder
-            .setFunctionName("DISTINCT")
+            .setFunctionName("DISTINCT_ARRAY")
             .setAlias("total_population_in_Mars")
             .build();
     assertEquals("total_population_in_Mars", aggregationAliasProvider.getAlias(expression));

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/aggregation/AggregationColumnProviderTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/aggregation/AggregationColumnProviderTest.java
@@ -27,7 +27,7 @@ class AggregationColumnProviderTest {
             .build();
 
     final Function function =
-        Function.newBuilder().setFunctionName("DISTINCT").addArguments(exp1).build();
+        Function.newBuilder().setFunctionName("DISTINCT_ARRAY").addArguments(exp1).build();
 
     final Expression result = aggregationColumnProvider.getAggregationColumn(function);
 
@@ -41,7 +41,7 @@ class AggregationColumnProviderTest {
 
     final Function function =
         Function.newBuilder()
-            .setFunctionName("DISTINCT")
+            .setFunctionName("DISTINCT_ARRAY")
             .addArguments(Expression.newBuilder().setColumnIdentifier(col1).build())
             .addArguments(Expression.newBuilder().setColumnIdentifier(col2).build())
             .build();


### PR DESCRIPTION
## Description
This PR updates document store library version(accordingly impl changes) and adds conversion for DISTINCT_ARRAY operator. It is the same as the current DISTINCT. Current DISTINCT support would be removed once the upstream services are migrated.
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Updated unit tests and verified that they run successfully.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
