### PR TITLE
chore: adding serde for entity change event key and value

### DIFF
--- a/entity-service-change-event-api/build.gradle.kts
+++ b/entity-service-change-event-api/build.gradle.kts
@@ -23,5 +23,6 @@ sourceSets {
 
 dependencies {
   api("com.google.protobuf:protobuf-java:3.19.1")
+  api("org.apache.kafka:kafka-clients:6.0.1-ccs")
   api(project(":entity-service-api"))
 }

--- a/entity-service-change-event-api/src/main/java/org/hypertrace/entity/change/event/v1/EntityChangeEventKeyDeserializer.java
+++ b/entity-service-change-event-api/src/main/java/org/hypertrace/entity/change/event/v1/EntityChangeEventKeyDeserializer.java
@@ -1,0 +1,16 @@
+package org.hypertrace.entity.change.event.v1;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.apache.kafka.common.serialization.Deserializer;
+
+public class EntityChangeEventKeyDeserializer implements Deserializer<EntityChangeEventKey> {
+
+  @Override
+  public EntityChangeEventKey deserialize(String topic, byte[] data) {
+    try {
+      return EntityChangeEventKey.parseFrom(data);
+    } catch (InvalidProtocolBufferException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/entity-service-change-event-api/src/main/java/org/hypertrace/entity/change/event/v1/EntityChangeEventKeySerde.java
+++ b/entity-service-change-event-api/src/main/java/org/hypertrace/entity/change/event/v1/EntityChangeEventKeySerde.java
@@ -1,0 +1,25 @@
+package org.hypertrace.entity.change.event.v1;
+
+import java.util.Map;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serializer;
+
+public class EntityChangeEventKeySerde implements Serde<EntityChangeEventKey> {
+
+  @Override
+  public void configure(Map<String, ?> configs, boolean isKey) {}
+
+  @Override
+  public void close() {}
+
+  @Override
+  public Serializer<EntityChangeEventKey> serializer() {
+    return new EntityChangeEventKeySerializer();
+  }
+
+  @Override
+  public Deserializer<EntityChangeEventKey> deserializer() {
+    return new EntityChangeEventKeyDeserializer();
+  }
+}

--- a/entity-service-change-event-api/src/main/java/org/hypertrace/entity/change/event/v1/EntityChangeEventKeySerializer.java
+++ b/entity-service-change-event-api/src/main/java/org/hypertrace/entity/change/event/v1/EntityChangeEventKeySerializer.java
@@ -1,0 +1,11 @@
+package org.hypertrace.entity.change.event.v1;
+
+import org.apache.kafka.common.serialization.Serializer;
+
+public class EntityChangeEventKeySerializer implements Serializer<EntityChangeEventKey> {
+
+  @Override
+  public byte[] serialize(String topic, EntityChangeEventKey data) {
+    return data.toByteArray();
+  }
+}

--- a/entity-service-change-event-api/src/main/java/org/hypertrace/entity/change/event/v1/EntityChangeEventValueDeserializer.java
+++ b/entity-service-change-event-api/src/main/java/org/hypertrace/entity/change/event/v1/EntityChangeEventValueDeserializer.java
@@ -1,0 +1,16 @@
+package org.hypertrace.entity.change.event.v1;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.apache.kafka.common.serialization.Deserializer;
+
+public class EntityChangeEventValueDeserializer implements Deserializer<EntityChangeEventValue> {
+
+  @Override
+  public EntityChangeEventValue deserialize(String topic, byte[] data) {
+    try {
+      return EntityChangeEventValue.parseFrom(data);
+    } catch (InvalidProtocolBufferException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/entity-service-change-event-api/src/main/java/org/hypertrace/entity/change/event/v1/EntityChangeEventValueSerde.java
+++ b/entity-service-change-event-api/src/main/java/org/hypertrace/entity/change/event/v1/EntityChangeEventValueSerde.java
@@ -1,0 +1,25 @@
+package org.hypertrace.entity.change.event.v1;
+
+import java.util.Map;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serializer;
+
+public class EntityChangeEventValueSerde implements Serde<EntityChangeEventValue> {
+
+  @Override
+  public void configure(Map<String, ?> configs, boolean isKey) {}
+
+  @Override
+  public void close() {}
+
+  @Override
+  public Serializer<EntityChangeEventValue> serializer() {
+    return new EntityChangeEventValueSerializer();
+  }
+
+  @Override
+  public Deserializer<EntityChangeEventValue> deserializer() {
+    return new EntityChangeEventValueDeserializer();
+  }
+}

--- a/entity-service-change-event-api/src/main/java/org/hypertrace/entity/change/event/v1/EntityChangeEventValueSerializer.java
+++ b/entity-service-change-event-api/src/main/java/org/hypertrace/entity/change/event/v1/EntityChangeEventValueSerializer.java
@@ -1,0 +1,11 @@
+package org.hypertrace.entity.change.event.v1;
+
+import org.apache.kafka.common.serialization.Serializer;
+
+public class EntityChangeEventValueSerializer implements Serializer<EntityChangeEventValue> {
+
+  @Override
+  public byte[] serialize(String topic, EntityChangeEventValue data) {
+    return data.toByteArray();
+  }
+}

--- a/entity-service-change-event-generator/build.gradle.kts
+++ b/entity-service-change-event-generator/build.gradle.kts
@@ -27,8 +27,6 @@ dependencies {
     }
   }
 
-  runtimeOnly("io.confluent:kafka-protobuf-serializer:6.0.1")
-
   annotationProcessor("org.projectlombok:lombok:1.18.18")
   compileOnly("org.projectlombok:lombok:1.18.18")
 

--- a/entity-service/src/main/resources/configs/common/application.conf
+++ b/entity-service/src/main/resources/configs/common/application.conf
@@ -108,8 +108,8 @@ event.store {
   entity.change.events.producer {
     topic.name = entity-change-events
     bootstrap.servers = "localhost:9092"
-    key.serializer = io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer
-    value.serializer = io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer
+    key.serializer = org.hypertrace.entity.change.event.v1.EntityChangeEventKeySerializer
+    value.serializer = org.hypertrace.entity.change.event.v1.EntityChangeEventValueSerializer
     schema.registry.url = "http://localhost:8081"
   }
 }


### PR DESCRIPTION
## Description
This PR adds serde for entity change event key and value.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
