### PR TITLE
Update operators implementation

### DIFF
--- a/entity-service-api/src/main/proto/org/hypertrace/entity/query/service/v1/entity_query_service.proto
+++ b/entity-service-api/src/main/proto/org/hypertrace/entity/query/service/v1/entity_query_service.proto
@@ -22,6 +22,7 @@ service EntityQueryService {
   rpc total (TotalEntitiesRequest) returns (TotalEntitiesResponse) {
   }
   rpc bulkUpdateEntityArrayAttribute (BulkEntityArrayAttributeUpdateRequest) returns (BulkEntityArrayAttributeUpdateResponse) {
+    option deprecated = true; // Use "BulkUpdateAllMatchingFilter" instead
   }
   rpc deleteEntities (DeleteEntitiesRequest) returns (DeleteEntitiesResponse) {
   }

--- a/entity-service-factory/build.gradle.kts
+++ b/entity-service-factory/build.gradle.kts
@@ -8,5 +8,5 @@ dependencies {
   implementation(project(":entity-service-attribute-translator"))
   implementation(project(":entity-service-impl"))
   implementation(project(":entity-service-change-event-generator"))
-  implementation("org.hypertrace.core.documentstore:document-store:0.7.21")
+  implementation("org.hypertrace.core.documentstore:document-store:0.7.22")
 }

--- a/entity-service-factory/build.gradle.kts
+++ b/entity-service-factory/build.gradle.kts
@@ -8,5 +8,5 @@ dependencies {
   implementation(project(":entity-service-attribute-translator"))
   implementation(project(":entity-service-impl"))
   implementation(project(":entity-service-change-event-generator"))
-  implementation("org.hypertrace.core.documentstore:document-store:0.7.22")
+  implementation("org.hypertrace.core.documentstore:document-store:0.7.23")
 }

--- a/entity-service-impl/build.gradle.kts
+++ b/entity-service-impl/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
   annotationProcessor("org.projectlombok:lombok:1.18.22")
   compileOnly("org.projectlombok:lombok:1.18.18")
 
-  implementation("org.hypertrace.core.documentstore:document-store:0.7.23-SNAPSHOT")
+  implementation("org.hypertrace.core.documentstore:document-store:0.7.23")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.7.3")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.7.3")
   implementation("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.12.3")

--- a/entity-service-impl/build.gradle.kts
+++ b/entity-service-impl/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
   annotationProcessor("org.projectlombok:lombok:1.18.22")
   compileOnly("org.projectlombok:lombok:1.18.18")
 
-  implementation("org.hypertrace.core.documentstore:document-store:0.7.21")
+  implementation("org.hypertrace.core.documentstore:document-store:0.7.23-SNAPSHOT")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.7.3")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.7.3")
   implementation("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.12.3")

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryConverter.java
@@ -28,7 +28,7 @@ import org.hypertrace.entity.query.service.v1.SortOrder;
 import org.hypertrace.entity.query.service.v1.ValueType;
 import org.hypertrace.entity.service.constants.EntityServiceConstants;
 
-class EntityQueryConverter {
+public class EntityQueryConverter {
 
   private final EntityAttributeMapping attributeMapping;
 

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryConverter.java
@@ -28,7 +28,7 @@ import org.hypertrace.entity.query.service.v1.SortOrder;
 import org.hypertrace.entity.query.service.v1.ValueType;
 import org.hypertrace.entity.service.constants.EntityServiceConstants;
 
-public class EntityQueryConverter {
+class EntityQueryConverter {
 
   private final EntityAttributeMapping attributeMapping;
 

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/UpdateConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/UpdateConverter.java
@@ -1,58 +1,86 @@
 package org.hypertrace.entity.query.service.converter;
 
-import static org.hypertrace.entity.query.service.converter.identifier.IdentifierConverter.getSubDocPathById;
-import static org.hypertrace.entity.query.service.converter.identifier.IdentifierConverter.isPartOfAttributeMap;
+import static java.util.Map.entry;
+import static org.hypertrace.core.documentstore.model.subdoc.UpdateOperator.ADD_TO_LIST_IF_ABSENT;
+import static org.hypertrace.core.documentstore.model.subdoc.UpdateOperator.REMOVE_ALL_FROM_LIST;
+import static org.hypertrace.core.documentstore.model.subdoc.UpdateOperator.SET;
+import static org.hypertrace.core.documentstore.model.subdoc.UpdateOperator.UNSET;
+import static org.hypertrace.entity.query.service.converter.ValueHelper.VALUES_KEY;
+import static org.hypertrace.entity.query.service.converter.ValueHelper.VALUE_LIST_KEY;
+import static org.hypertrace.entity.query.service.v1.AttributeUpdateOperation.AttributeUpdateOperator.ATTRIBUTE_UPDATE_OPERATOR_ADD_TO_LIST_IF_ABSENT;
+import static org.hypertrace.entity.query.service.v1.AttributeUpdateOperation.AttributeUpdateOperator.ATTRIBUTE_UPDATE_OPERATOR_REMOVE_FROM_LIST;
 import static org.hypertrace.entity.query.service.v1.AttributeUpdateOperation.AttributeUpdateOperator.ATTRIBUTE_UPDATE_OPERATOR_SET;
+import static org.hypertrace.entity.query.service.v1.AttributeUpdateOperation.AttributeUpdateOperator.ATTRIBUTE_UPDATE_OPERATOR_UNSET;
 
+import com.google.common.base.Joiner;
+import java.util.Map;
+import java.util.Optional;
 import javax.inject.Inject;
 import lombok.AllArgsConstructor;
+import org.hypertrace.core.documentstore.model.subdoc.SubDocument;
 import org.hypertrace.core.documentstore.model.subdoc.SubDocumentUpdate;
+import org.hypertrace.core.documentstore.model.subdoc.SubDocumentUpdate.SubDocumentUpdateBuilder;
 import org.hypertrace.core.documentstore.model.subdoc.SubDocumentValue;
+import org.hypertrace.core.documentstore.model.subdoc.UpdateOperator;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.entity.attribute.translator.EntityAttributeMapping;
-import org.hypertrace.entity.query.service.converter.identifier.IdentifierConversionMetadata;
-import org.hypertrace.entity.query.service.converter.identifier.IdentifierConverter;
-import org.hypertrace.entity.query.service.converter.identifier.IdentifierConverterFactory;
 import org.hypertrace.entity.query.service.v1.AttributeUpdateOperation;
+import org.hypertrace.entity.query.service.v1.AttributeUpdateOperation.AttributeUpdateOperator;
 import org.hypertrace.entity.query.service.v1.Value;
-import org.hypertrace.entity.query.service.v1.ValueType;
 
 @AllArgsConstructor(onConstructor_ = {@Inject})
 public class UpdateConverter implements Converter<AttributeUpdateOperation, SubDocumentUpdate> {
+  private static final Joiner DOT_JOINER = Joiner.on(".");
+
+  private static final Map<AttributeUpdateOperator, UpdateOperator> OPERATOR_MAP =
+      Map.ofEntries(
+          entry(ATTRIBUTE_UPDATE_OPERATOR_SET, SET),
+          entry(ATTRIBUTE_UPDATE_OPERATOR_UNSET, UNSET),
+          entry(ATTRIBUTE_UPDATE_OPERATOR_ADD_TO_LIST_IF_ABSENT, ADD_TO_LIST_IF_ABSENT),
+          entry(ATTRIBUTE_UPDATE_OPERATOR_REMOVE_FROM_LIST, REMOVE_ALL_FROM_LIST));
+
   private final EntityAttributeMapping entityAttributeMapping;
-  private final IdentifierConverterFactory identifierConverterFactory;
   private final ValueHelper valueHelper;
 
   @Override
   public SubDocumentUpdate convert(
       final AttributeUpdateOperation operation, final RequestContext context)
       throws ConversionException {
-    final String id = operation.getAttribute().getColumnName();
-    final String subDocPath = getSubDocPathById(entityAttributeMapping, id, context);
+    final UpdateOperator operator = OPERATOR_MAP.get(operation.getOperator());
 
-    if (!isPartOfAttributeMap(subDocPath)) {
-      throw new ConversionException(String.format("Cannot update non-attribute value for %s", id));
-    }
-
-    final Value value = operation.getValue().getValue();
-    final ValueType valueType = value.getValueType();
-
-    final IdentifierConverter identifierConverter =
-        identifierConverterFactory.getIdentifierConverter(id, subDocPath, valueType, context);
-    final String suffixedSubDocPath =
-        identifierConverter.convert(
-            IdentifierConversionMetadata.builder()
-                .subDocPath(subDocPath)
-                .valueType(valueType)
-                .build(),
-            context);
-    final SubDocumentValue subDocValue = valueHelper.convertToSubDocumentValue(value);
-
-    if (operation.getOperator() == ATTRIBUTE_UPDATE_OPERATOR_SET) {
-      return SubDocumentUpdate.of(suffixedSubDocPath, subDocValue);
-    } else {
+    if (operator == null) {
       throw new ConversionException(
           String.format("Operator %s is not supported yet", operation.getOperator()));
     }
+
+    final String id = operation.getAttribute().getColumnName();
+    final Optional<String> pathOptional =
+        entityAttributeMapping.getDocStorePathByAttributeId(context, id);
+
+    if (pathOptional.isEmpty()) {
+      throw new ConversionException(String.format("Cannot update non-attribute value for %s", id));
+    }
+
+    final String subDocPath = pathOptional.orElseThrow();
+    final Value value = operation.getValue().getValue();
+    final String suffixedSubDocPath;
+
+    if (entityAttributeMapping.isMultiValued(context, id)) {
+      suffixedSubDocPath = DOT_JOINER.join(subDocPath, VALUE_LIST_KEY, VALUES_KEY);
+    } else {
+      suffixedSubDocPath = subDocPath;
+    }
+
+    final SubDocumentUpdateBuilder updateBuilder =
+        SubDocumentUpdate.builder()
+            .subDocument(SubDocument.builder().path(suffixedSubDocPath).build())
+            .operator(operator);
+
+    if (operator != UNSET) {
+      final SubDocumentValue subDocValue = valueHelper.convertToSubDocumentValue(value);
+      updateBuilder.subDocumentValue(subDocValue);
+    }
+
+    return updateBuilder.build();
   }
 }

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/EntityQueryServiceImplTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/EntityQueryServiceImplTest.java
@@ -6,8 +6,6 @@ import static org.hypertrace.entity.TestUtils.convertToCloseableIterator;
 import static org.hypertrace.entity.query.service.v1.AttributeUpdateOperation.AttributeUpdateOperator.ATTRIBUTE_UPDATE_OPERATOR_SET;
 import static org.hypertrace.entity.service.constants.EntityConstants.ENTITY_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -43,8 +41,8 @@ import org.hypertrace.core.documentstore.expression.impl.KeyExpression;
 import org.hypertrace.core.documentstore.expression.impl.RelationalExpression;
 import org.hypertrace.core.documentstore.expression.operators.RelationalOperator;
 import org.hypertrace.core.documentstore.model.options.UpdateOptions;
-import org.hypertrace.core.documentstore.model.subdoc.PrimitiveSubDocumentValue;
 import org.hypertrace.core.documentstore.model.subdoc.SubDocumentUpdate;
+import org.hypertrace.core.documentstore.model.subdoc.SubDocumentValue;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.entity.attribute.translator.EntityAttributeChangeEvaluator;
 import org.hypertrace.entity.attribute.translator.EntityAttributeMapping;
@@ -668,22 +666,13 @@ public class EntityQueryServiceImplTest {
                   org.hypertrace.core.documentstore.query.Query.builder()
                       .setFilter(KeyExpression.of(new SingleValueKey(TENANT_ID, entityId)))
                       .build()),
-              valueCaptor.capture(),
+              eq(
+                  List.of(
+                      SubDocumentUpdate.of(
+                          "attributes.entity_id",
+                          SubDocumentValue.of(
+                              new JSONDocument("{\"value\":{\"string\":\"NEW_STATUS\"}}"))))),
               eq(UpdateOptions.builder().returnDocumentType(NONE).build()));
-
-      final Object capturedRaw = valueCaptor.getValue();
-
-      assertNotNull(capturedRaw);
-      assertEquals(1, ((List<?>) capturedRaw).size());
-
-      final Object firstValRaw = ((List<?>) capturedRaw).get(0);
-      assertTrue(firstValRaw instanceof SubDocumentUpdate);
-
-      final SubDocumentUpdate update = (SubDocumentUpdate) firstValRaw;
-      assertEquals("attributes.entity_id.value.string", update.getSubDocument().getPath());
-      assertEquals(
-          "NEW_STATUS",
-          ((PrimitiveSubDocumentValue) update.getSubDocumentValue()).getValue().toString());
     }
   }
 

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/UpdateConverterTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/converter/UpdateConverterTest.java
@@ -3,25 +3,28 @@ package org.hypertrace.entity.query.service.converter;
 import static org.hypertrace.entity.query.service.v1.AttributeUpdateOperation.AttributeUpdateOperator.ATTRIBUTE_UPDATE_OPERATOR_SET;
 import static org.hypertrace.entity.query.service.v1.ValueType.STRING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
-import org.hypertrace.core.documentstore.model.subdoc.PrimitiveSubDocumentValue;
+import org.hypertrace.core.documentstore.JSONDocument;
 import org.hypertrace.core.documentstore.model.subdoc.SubDocumentUpdate;
+import org.hypertrace.core.documentstore.model.subdoc.SubDocumentValue;
 import org.hypertrace.core.grpcutils.context.RequestContext;
 import org.hypertrace.entity.attribute.translator.EntityAttributeMapping;
 import org.hypertrace.entity.query.service.converter.accessor.ValueOneOfAccessor;
-import org.hypertrace.entity.query.service.converter.identifier.IdentifierConversionMetadata;
-import org.hypertrace.entity.query.service.converter.identifier.IdentifierConverter;
-import org.hypertrace.entity.query.service.converter.identifier.IdentifierConverterFactory;
 import org.hypertrace.entity.query.service.v1.AttributeUpdateOperation;
+import org.hypertrace.entity.query.service.v1.AttributeUpdateOperation.AttributeUpdateOperator;
 import org.hypertrace.entity.query.service.v1.ColumnIdentifier;
 import org.hypertrace.entity.query.service.v1.LiteralConstant;
 import org.hypertrace.entity.query.service.v1.Value;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -29,18 +32,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class UpdateConverterTest {
 
   @Mock private EntityAttributeMapping mockEntityAttributeMapping;
-  @Mock private IdentifierConverterFactory mockIdentifierConverterFactory;
-  @Mock private IdentifierConverter mockIdentifierConverter;
 
   private UpdateConverter updateConverter;
 
   @BeforeEach
   void setUp() {
     updateConverter =
-        new UpdateConverter(
-            mockEntityAttributeMapping,
-            mockIdentifierConverterFactory,
-            new ValueHelper(new ValueOneOfAccessor()));
+        new UpdateConverter(mockEntityAttributeMapping, new ValueHelper(new ValueOneOfAccessor()));
   }
 
   @Test
@@ -55,29 +53,39 @@ class UpdateConverterTest {
             .build();
     final RequestContext requestContext = new RequestContext();
     final SubDocumentUpdate expectedResult =
-        SubDocumentUpdate.of("attributes.sub_doc_path.value.string", "value");
+        SubDocumentUpdate.of(
+            "attributes.subDocPath",
+            SubDocumentValue.of(new JSONDocument("{\"value\":{\"string\":\"value\"}}")));
     when(mockEntityAttributeMapping.getDocStorePathByAttributeId(requestContext, "columnName"))
         .thenReturn(Optional.of("attributes.subDocPath"));
-    when(mockIdentifierConverterFactory.getIdentifierConverter(
-            "columnName", "attributes.subDocPath", STRING, requestContext))
-        .thenReturn(mockIdentifierConverter);
-    when(mockIdentifierConverter.convert(
-            IdentifierConversionMetadata.builder()
-                .valueType(STRING)
-                .subDocPath("attributes.subDocPath")
-                .build(),
-            requestContext))
-        .thenReturn("attributes.sub_doc_path.value.string");
     final SubDocumentUpdate result = updateConverter.convert(operation, requestContext);
 
-    assertEquals(expectedResult.getSubDocument().getPath(), result.getSubDocument().getPath());
-    assertEquals(
-        ((PrimitiveSubDocumentValue) expectedResult.getSubDocumentValue()).getValue().toString(),
-        ((PrimitiveSubDocumentValue) result.getSubDocumentValue()).getValue().toString());
+    assertEquals(expectedResult, result);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = AttributeUpdateOperator.class,
+      mode = Mode.EXCLUDE,
+      names = {"ATTRIBUTE_UPDATE_OPERATION_UNSPECIFIED", "UNRECOGNIZED"})
+  void testOperatorCoverage(final AttributeUpdateOperator operator) throws Exception {
+    final AttributeUpdateOperation operation =
+        AttributeUpdateOperation.newBuilder()
+            .setAttribute(ColumnIdentifier.newBuilder().setColumnName("columnName"))
+            .setOperator(operator)
+            .setValue(
+                LiteralConstant.newBuilder()
+                    .setValue(Value.newBuilder().setValueType(STRING).setString("value")))
+            .build();
+    final RequestContext requestContext = new RequestContext();
+    when(mockEntityAttributeMapping.getDocStorePathByAttributeId(requestContext, "columnName"))
+        .thenReturn(Optional.of("attributes.subDocPath"));
+    final SubDocumentUpdate result = updateConverter.convert(operation, requestContext);
+    assertNotNull(result);
   }
 
   @Test
-  void testConvertNonAttributeValue() throws Exception {
+  void testConvertNonAttributeValue() {
     final AttributeUpdateOperation operation =
         AttributeUpdateOperation.newBuilder()
             .setAttribute(ColumnIdentifier.newBuilder().setColumnName("columnName"))
@@ -88,7 +96,7 @@ class UpdateConverterTest {
             .build();
     final RequestContext requestContext = new RequestContext();
     when(mockEntityAttributeMapping.getDocStorePathByAttributeId(requestContext, "columnName"))
-        .thenReturn(Optional.of("subDocPath"));
+        .thenReturn(Optional.empty());
     assertThrows(
         ConversionException.class, () -> updateConverter.convert(operation, requestContext));
   }

--- a/entity-service/build.gradle.kts
+++ b/entity-service/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
   implementation(project(":entity-service-factory"))
 
   implementation("org.hypertrace.core.serviceframework:platform-grpc-service-framework:0.1.37")
-  implementation("org.hypertrace.core.documentstore:document-store:0.7.22")
+  implementation("org.hypertrace.core.documentstore:document-store:0.7.23")
 
   runtimeOnly("io.grpc:grpc-netty:1.45.1")
 

--- a/entity-service/build.gradle.kts
+++ b/entity-service/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
   implementation(project(":entity-service-factory"))
 
   implementation("org.hypertrace.core.serviceframework:platform-grpc-service-framework:0.1.37")
-  implementation("org.hypertrace.core.documentstore:document-store:0.7.21")
+  implementation("org.hypertrace.core.documentstore:document-store:0.7.22")
 
   runtimeOnly("io.grpc:grpc-netty:1.45.1")
 


### PR DESCRIPTION
## Description
Added support for the update operators in addition to SET.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Added necessary unit and integration tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
