### PR TITLE
Reverted #167 to remove the queryAggregationEnabled flag

### DIFF
--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryServiceImpl.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/EntityQueryServiceImpl.java
@@ -8,13 +8,11 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toUnmodifiableList;
 import static org.hypertrace.core.documentstore.expression.operators.RelationalOperator.IN;
 import static org.hypertrace.core.documentstore.model.options.ReturnDocumentType.NONE;
-import static org.hypertrace.entity.attribute.translator.EntityAttributeMapping.ENTITY_ATTRIBUTE_DOC_PREFIX;
 import static org.hypertrace.entity.data.service.v1.AttributeValue.VALUE_LIST_FIELD_NUMBER;
 import static org.hypertrace.entity.data.service.v1.AttributeValueList.VALUES_FIELD_NUMBER;
 import static org.hypertrace.entity.query.service.v1.ValueType.STRING;
 import static org.hypertrace.entity.service.constants.EntityCollectionConstants.RAW_ENTITIES_COLLECTION;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -85,7 +83,6 @@ import org.hypertrace.entity.query.service.v1.EntityQueryRequest;
 import org.hypertrace.entity.query.service.v1.EntityQueryServiceGrpc.EntityQueryServiceImplBase;
 import org.hypertrace.entity.query.service.v1.EntityUpdateRequest;
 import org.hypertrace.entity.query.service.v1.Expression;
-import org.hypertrace.entity.query.service.v1.Expression.ValueCase;
 import org.hypertrace.entity.query.service.v1.Function;
 import org.hypertrace.entity.query.service.v1.LiteralConstant;
 import org.hypertrace.entity.query.service.v1.ResultSetChunk;
@@ -99,7 +96,6 @@ import org.hypertrace.entity.query.service.v1.UpdateOperation;
 import org.hypertrace.entity.query.service.v1.UpdateSummary;
 import org.hypertrace.entity.query.service.v1.UpdatedEntity;
 import org.hypertrace.entity.query.service.v1.Value;
-import org.hypertrace.entity.query.service.v1.ValueType;
 import org.hypertrace.entity.service.change.event.api.EntityChangeEventGenerator;
 import org.hypertrace.entity.service.constants.EntityServiceConstants;
 import org.hypertrace.entity.service.util.DocStoreConverter;
@@ -115,8 +111,6 @@ public class EntityQueryServiceImpl extends EntityQueryServiceImplBase {
   private static final Printer PRINTER = DocStoreJsonFormat.printer().includingDefaultValueFields();
   private static final DocumentParser DOCUMENT_PARSER = new DocumentParser();
   private static final String CHUNK_SIZE_CONFIG = "entity.query.service.response.chunk.size";
-  private static final String QUERY_AGGREGATION_ENABLED_CONFIG =
-      "entity.service.config.query.aggregation.enabled";
   private static final String ENTITY_IDS_DELETE_LIMIT_CONFIG = "entity.delete.limit";
 
   private static final int DEFAULT_CHUNK_SIZE = 10_000;
@@ -137,7 +131,6 @@ public class EntityQueryServiceImpl extends EntityQueryServiceImplBase {
   private final EntityAttributeMapping entityAttributeMapping;
   private final int CHUNK_SIZE;
   private final Injector injector;
-  private final boolean queryAggregationEnabled;
   private final int maxEntitiesToDelete;
   private final EntityFetcher entityFetcher;
   private final EntityChangeEventGenerator entityChangeEventGenerator;
@@ -159,8 +152,6 @@ public class EntityQueryServiceImpl extends EntityQueryServiceImplBase {
         !config.hasPathOrNull(CHUNK_SIZE_CONFIG)
             ? DEFAULT_CHUNK_SIZE
             : config.getInt(CHUNK_SIZE_CONFIG),
-        config.hasPath(QUERY_AGGREGATION_ENABLED_CONFIG)
-            && config.getBoolean(QUERY_AGGREGATION_ENABLED_CONFIG),
         config.hasPath(ENTITY_IDS_DELETE_LIMIT_CONFIG)
             ? config.getInt(ENTITY_IDS_DELETE_LIMIT_CONFIG)
             : 10000);
@@ -173,7 +164,6 @@ public class EntityQueryServiceImpl extends EntityQueryServiceImplBase {
       EntityAttributeChangeEvaluator entityAttributeChangeEvaluator,
       EntityCounterMetricSender entityCounterMetricSender,
       int chunkSize,
-      boolean queryAggregationEnabled,
       int maxEntitiesToDelete) {
     this(
         entitiesCollection,
@@ -183,11 +173,9 @@ public class EntityQueryServiceImpl extends EntityQueryServiceImplBase {
         entityCounterMetricSender,
         new EntityFetcher(entitiesCollection, DOCUMENT_PARSER),
         chunkSize,
-        queryAggregationEnabled,
         maxEntitiesToDelete);
   }
 
-  @VisibleForTesting
   EntityQueryServiceImpl(
       Collection entitiesCollection,
       EntityAttributeMapping entityAttributeMapping,
@@ -196,14 +184,12 @@ public class EntityQueryServiceImpl extends EntityQueryServiceImplBase {
       EntityCounterMetricSender entityCounterMetricSender,
       EntityFetcher entityFetcher,
       int chunkSize,
-      boolean queryAggregationEnabled,
       int maxEntitiesToDelete) {
     this.entitiesCollection = entitiesCollection;
     this.entityAttributeMapping = entityAttributeMapping;
     this.entityQueryConverter = new EntityQueryConverter(entityAttributeMapping);
     this.CHUNK_SIZE = chunkSize;
     this.injector = Guice.createInjector(new ConverterModule(entityAttributeMapping));
-    this.queryAggregationEnabled = queryAggregationEnabled;
     this.maxEntitiesToDelete = maxEntitiesToDelete;
     this.entityChangeEventGenerator = entityChangeEventGenerator;
     this.entityFetcher = entityFetcher;
@@ -220,7 +206,14 @@ public class EntityQueryServiceImpl extends EntityQueryServiceImplBase {
       return;
     }
 
-    try (CloseableIterator<Document> documentIterator = searchDocuments(requestContext, request)) {
+    final Converter<EntityQueryRequest, org.hypertrace.core.documentstore.query.Query>
+        queryConverter = getQueryConverter();
+    final org.hypertrace.core.documentstore.query.Query query;
+    final Iterator<Document> documentIterator;
+
+    try {
+      query = queryConverter.convert(request, requestContext);
+      documentIterator = entitiesCollection.aggregate(query);
       streamResponse(request, responseObserver, requestContext, documentIterator);
     } catch (Exception ex) {
       LOG.error("Error while executing entity query request ", ex);
@@ -232,11 +225,11 @@ public class EntityQueryServiceImpl extends EntityQueryServiceImplBase {
       final EntityQueryRequest request,
       final StreamObserver<ResultSetChunk> responseObserver,
       final RequestContext requestContext,
-      final CloseableIterator<Document> documentIterator)
+      final Iterator<Document> documentIterator)
       throws ConversionException {
     final DocumentConverter rowConverter = injector.getInstance(DocumentConverter.class);
-    ResultSetMetadata resultSetMetadata;
-    resultSetMetadata = this.buildMetadataForSelections(request.getSelectionList());
+    ResultSetMetadata resultSetMetadata =
+        this.buildMetadataForSelections(request.getSelectionList());
 
     if (!documentIterator.hasNext()) {
       ResultSetChunk.Builder resultBuilder = ResultSetChunk.newBuilder();
@@ -259,17 +252,9 @@ public class EntityQueryServiceImpl extends EntityQueryServiceImplBase {
       }
 
       try {
-        Optional<Row> row =
-            convertToRow(
-                requestContext,
-                documentIterator.next(),
-                resultSetMetadata,
-                rowConverter,
-                request.getSelectionList());
-        if (row.isPresent()) {
-          resultBuilder.addRow(row.get());
-          rowCount++;
-        }
+        final Row row = rowConverter.convertToRow(documentIterator.next(), resultSetMetadata);
+        resultBuilder.addRow(row);
+        rowCount++;
       } catch (final Exception e) {
         responseObserver.onError(new ServiceException(e));
         return;
@@ -286,58 +271,6 @@ public class EntityQueryServiceImpl extends EntityQueryServiceImplBase {
       }
     }
     responseObserver.onCompleted();
-  }
-
-  private Optional<Row> convertToRow(
-      RequestContext requestContext,
-      Document document,
-      ResultSetMetadata resultSetMetadata,
-      DocumentConverter rowConverter,
-      List<Expression> selectionList)
-      throws ConversionException {
-    final Row row;
-    if (queryAggregationEnabled) {
-      row = rowConverter.convertToRow(document, resultSetMetadata);
-      return Optional.of(row);
-    } else {
-      Optional<Entity> entity = DOCUMENT_PARSER.parseOrLog(document, Entity.newBuilder());
-
-      if (entity.isPresent()) {
-        row = convertToEntityQueryResult(requestContext, entity.get(), selectionList);
-        return Optional.of(row);
-      }
-    }
-    return Optional.empty();
-  }
-
-  private CloseableIterator<Document> searchDocuments(
-      RequestContext requestContext, EntityQueryRequest request) throws ConversionException {
-    final CloseableIterator<Document> documentIterator;
-    if (queryAggregationEnabled) {
-      final Converter<EntityQueryRequest, org.hypertrace.core.documentstore.query.Query>
-          queryConverter = getQueryConverter();
-      final org.hypertrace.core.documentstore.query.Query query;
-
-      query = queryConverter.convert(request, requestContext);
-      documentIterator = entitiesCollection.aggregate(query);
-    } else {
-      // TODO: Optimize this later. For now converting to EDS Query and then again to DocStore
-      // Query.
-      Query query = entityQueryConverter.convertToEDSQuery(requestContext, request);
-      /**
-       * {@link EntityQueryRequest} selections need to treated differently, since they don't
-       * transform one to one to {@link org.hypertrace.entity.data.service.v1.EntityDataRequest}
-       * selections
-       */
-      List<String> docStoreSelections =
-          entityQueryConverter.convertSelectionsToDocStoreSelections(
-              requestContext, request.getSelectionList());
-      documentIterator =
-          entitiesCollection.search(
-              DocStoreConverter.transform(
-                  requestContext.getTenantId().orElseThrow(), query, docStoreSelections));
-    }
-    return documentIterator;
   }
 
   private ResultSetChunk convertDocumentsToResultSetChunk(
@@ -991,62 +924,6 @@ public class EntityQueryServiceImpl extends EntityQueryServiceImplBase {
           .withDescription("Error while getting entity ids to delete")
           .asRuntimeException();
     }
-  }
-
-  @Deprecated(
-      since =
-          "Will be removed when Collection.find() and Collection.aggregate() are implemented for "
-              + "Postgres and the 'queryAggregationEnabled' helm-value is enabled",
-      forRemoval = true)
-  private Row convertToEntityQueryResult(
-      RequestContext requestContext, Entity entity, List<Expression> selections) {
-    Row.Builder result = Row.newBuilder();
-    selections.stream()
-        .filter(expression -> expression.getValueCase() == ValueCase.COLUMNIDENTIFIER)
-        .forEach(
-            expression -> {
-              String columnName = expression.getColumnIdentifier().getColumnName();
-              String edsSubDocPath =
-                  entityAttributeMapping
-                      .getDocStorePathByAttributeId(requestContext, columnName)
-                      .orElse(null);
-              if (edsSubDocPath != null) {
-                // Map the attr name to corresponding Attribute Key in EDS and get the EDS
-                // AttributeValue
-                if (edsSubDocPath.equals(EntityServiceConstants.ENTITY_ID)) {
-                  result.addColumn(
-                      Value.newBuilder()
-                          .setValueType(STRING)
-                          .setString(entity.getEntityId())
-                          .build());
-                } else if (edsSubDocPath.equals(EntityServiceConstants.ENTITY_NAME)) {
-                  result.addColumn(
-                      Value.newBuilder()
-                          .setValueType(STRING)
-                          .setString(entity.getEntityName())
-                          .build());
-                } else if (edsSubDocPath.equals(EntityServiceConstants.ENTITY_CREATED_TIME)) {
-                  result.addColumn(
-                      Value.newBuilder()
-                          .setValueType(ValueType.LONG)
-                          .setLong(entity.getCreatedTime())
-                          .build());
-                } else if (edsSubDocPath.startsWith(ENTITY_ATTRIBUTE_DOC_PREFIX)) {
-                  // Convert EDS AttributeValue to Gateway Value
-                  AttributeValue attributeValue =
-                      entity.getAttributesMap().get(edsSubDocPath.split("\\.")[1]);
-                  result.addColumn(
-                      EntityQueryConverter.convertAttributeValueToQueryValue(attributeValue));
-                } else {
-                  LOG.error(
-                      "Unable to add column {} for sub doc path {}", columnName, edsSubDocPath);
-                }
-              } else {
-                LOG.warn("columnName {} missing in attrNameToEDSAttrMap", columnName);
-                result.addColumn(Value.getDefaultInstance());
-              }
-            });
-    return result.build();
   }
 
   private ResultSetMetadata buildMetadataForSelections(List<Expression> selections)

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/FilterConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/filter/FilterConverter.java
@@ -28,10 +28,10 @@ public class FilterConverter implements Converter<EntityQueryRequest, Filter> {
     } else {
       final Converter<org.hypertrace.entity.query.service.v1.Filter, ? extends FilterTypeExpression>
           filterConverter = filterConverterFactory.getFilterConverter(filter.getOperator());
-      final FilterTypeExpression filterTypeExpression =
+      final FilterTypeExpression filteringExpression =
           filterConverter.convert(filter, requestContext);
       allFilters =
-          extraFiltersApplier.addExtraFilters(filterTypeExpression, request, requestContext);
+          extraFiltersApplier.addExtraFilters(filteringExpression, request, requestContext);
     }
 
     return Filter.builder().expression(allFilters).build();

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/selection/SelectionConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/query/service/converter/selection/SelectionConverter.java
@@ -48,10 +48,10 @@ public class SelectionConverter implements Converter<List<Expression>, Selection
         selectionFactory.getConverter(valueCase);
     final AliasProvider<T> aliasProvider = selectionFactory.getAliasProvider(valueCase);
 
-    final SelectTypeExpression selectTypeExpression =
+    final SelectTypeExpression selectingExpression =
         converter.convert(innerExpression, requestContext);
     final String alias = aliasProvider.getAlias(innerExpression);
 
-    return SelectionSpec.of(selectTypeExpression, alias);
+    return SelectionSpec.of(selectingExpression, alias);
   }
 }

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/EntityQueryServiceImplTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/EntityQueryServiceImplTest.java
@@ -133,7 +133,6 @@ public class EntityQueryServiceImplTest {
                       new EntityCounterMetricSender(),
                       entityFetcher,
                       1,
-                      false,
                       1000);
 
               eqs.update(null, mockResponseObserver);
@@ -162,7 +161,6 @@ public class EntityQueryServiceImplTest {
                       new EntityCounterMetricSender(),
                       entityFetcher,
                       1,
-                      false,
                       1000);
 
               eqs.update(EntityUpdateRequest.newBuilder().build(), mockResponseObserver);
@@ -192,7 +190,6 @@ public class EntityQueryServiceImplTest {
                       new EntityCounterMetricSender(),
                       entityFetcher,
                       1,
-                      false,
                       1000);
 
               eqs.update(
@@ -224,7 +221,6 @@ public class EntityQueryServiceImplTest {
                       new EntityCounterMetricSender(),
                       entityFetcher,
                       1,
-                      false,
                       1000);
 
               eqs.update(
@@ -285,7 +281,6 @@ public class EntityQueryServiceImplTest {
                       new EntityCounterMetricSender(),
                       entityFetcher,
                       1,
-                      false,
                       1000);
               eqs.update(updateRequest, mockResponseObserver);
               return null;
@@ -321,7 +316,6 @@ public class EntityQueryServiceImplTest {
                         new EntityCounterMetricSender(),
                         entityFetcher,
                         1,
-                        false,
                         1000);
 
                 eqs.bulkUpdate(null, mockResponseObserver);
@@ -351,7 +345,6 @@ public class EntityQueryServiceImplTest {
                         new EntityCounterMetricSender(),
                         entityFetcher,
                         1,
-                        false,
                         1000);
 
                 eqs.bulkUpdate(BulkEntityUpdateRequest.newBuilder().build(), mockResponseObserver);
@@ -381,7 +374,6 @@ public class EntityQueryServiceImplTest {
                         new EntityCounterMetricSender(),
                         entityFetcher,
                         1,
-                        false,
                         1000);
 
                 eqs.bulkUpdate(
@@ -420,7 +412,6 @@ public class EntityQueryServiceImplTest {
                         new EntityCounterMetricSender(),
                         entityFetcher,
                         1,
-                        false,
                         1000);
                 eqs.bulkUpdate(bulkUpdateRequest, mockResponseObserver);
                 return null;
@@ -465,7 +456,6 @@ public class EntityQueryServiceImplTest {
                         new EntityCounterMetricSender(),
                         entityFetcher,
                         1,
-                        false,
                         1000);
                 eqs.bulkUpdate(bulkUpdateRequest, mockResponseObserver);
                 return null;
@@ -504,7 +494,6 @@ public class EntityQueryServiceImplTest {
                         new EntityCounterMetricSender(),
                         entityFetcher,
                         1,
-                        false,
                         1000);
 
                 eqs.bulkUpdateAllMatchingFilter(null, mockResponseObserver);
@@ -536,7 +525,6 @@ public class EntityQueryServiceImplTest {
                         new EntityCounterMetricSender(),
                         entityFetcher,
                         1,
-                        false,
                         1000);
 
                 eqs.bulkUpdateAllMatchingFilter(
@@ -572,7 +560,6 @@ public class EntityQueryServiceImplTest {
                         new EntityCounterMetricSender(),
                         entityFetcher,
                         1,
-                        false,
                         1000);
                 eqs.bulkUpdateAllMatchingFilter(bulkUpdateRequest, mockResponseObserver);
 
@@ -666,7 +653,6 @@ public class EntityQueryServiceImplTest {
                         new EntityCounterMetricSender(),
                         entityFetcher,
                         1,
-                        false,
                         1000);
                 eqs.bulkUpdateAllMatchingFilter(bulkUpdateRequest, mockResponseObserver);
                 return null;
@@ -708,7 +694,6 @@ public class EntityQueryServiceImplTest {
                       new EntityCounterMetricSender(),
                       entityFetcher,
                       1,
-                      false,
                       1000);
 
               eqs.execute(null, mockResponseObserver);
@@ -758,8 +743,6 @@ public class EntityQueryServiceImplTest {
             new JSONDocument("{\"entityId\": [1, 2]}"));
     when(mockEntitiesCollection.aggregate(any()))
         .thenReturn(convertToCloseableIterator(docs.iterator()));
-    when(mockEntitiesCollection.search(any()))
-        .thenReturn(convertToCloseableIterator(docs.iterator()));
     EntityQueryRequest request =
         EntityQueryRequest.newBuilder()
             .setEntityType(TEST_ENTITY_TYPE)
@@ -785,15 +768,13 @@ public class EntityQueryServiceImplTest {
                       entityAttributeChangeEvaluator,
                       new EntityCounterMetricSender(),
                       1,
-                      false,
                       1000);
 
               eqs.execute(request, mockResponseObserver);
               return null;
             });
 
-    verify(mockEntitiesCollection, times(0)).aggregate(any());
-    verify(mockEntitiesCollection, times(1)).search(any());
+    verify(mockEntitiesCollection, times(1)).aggregate(any());
     verify(mockResponseObserver, times(3)).onNext(any());
     verify(mockResponseObserver, times(1)).onCompleted();
   }
@@ -851,9 +832,6 @@ public class EntityQueryServiceImplTest {
             new JSONDocument("{\"entityId\": [1, 2]}"));
     when(mockEntitiesCollection.aggregate(any()))
         .thenReturn(convertToCloseableIterator(docs.iterator()));
-    when(mockEntitiesCollection.search(any()))
-        .thenReturn(convertToCloseableIterator(docs.iterator()));
-
     EntityQueryRequest request =
         EntityQueryRequest.newBuilder()
             .setEntityType(TEST_ENTITY_TYPE)
@@ -879,15 +857,13 @@ public class EntityQueryServiceImplTest {
                       entityAttributeChangeEvaluator,
                       new EntityCounterMetricSender(),
                       2,
-                      false,
                       1000);
 
               eqs.execute(request, mockResponseObserver);
               return null;
             });
 
-    verify(mockEntitiesCollection, times(0)).aggregate(any());
-    verify(mockEntitiesCollection, times(1)).search(any());
+    verify(mockEntitiesCollection, times(1)).aggregate(any());
     verify(mockResponseObserver, times(2)).onNext(any());
     verify(mockResponseObserver, times(1)).onCompleted();
   }
@@ -933,7 +909,6 @@ public class EntityQueryServiceImplTest {
                       new EntityCounterMetricSender(),
                       entityFetcher,
                       1,
-                      false,
                       1000);
               eqs.bulkUpdateEntityArrayAttribute(request, mockResponseObserver);
               return null;
@@ -1005,7 +980,6 @@ public class EntityQueryServiceImplTest {
                       new EntityCounterMetricSender(),
                       entityFetcher,
                       100,
-                      false,
                       1000);
 
               eqs.deleteEntities(request, mockResponseObserver);
@@ -1048,9 +1022,6 @@ public class EntityQueryServiceImplTest {
                     + "}"));
     when(mockEntitiesCollection.aggregate(any()))
         .thenReturn(convertToCloseableIterator(docs.iterator()));
-    when(mockEntitiesCollection.search(any()))
-        .thenReturn(convertToCloseableIterator(docs.iterator()));
-
     EntityQueryRequest request =
         EntityQueryRequest.newBuilder()
             .setEntityType(TEST_ENTITY_TYPE)
@@ -1080,7 +1051,6 @@ public class EntityQueryServiceImplTest {
                       new EntityCounterMetricSender(),
                       entityFetcher,
                       100,
-                      false,
                       1000);
 
               eqs.execute(request, mockResponseObserver);
@@ -1126,7 +1096,6 @@ public class EntityQueryServiceImplTest {
               new EntityCounterMetricSender(),
               entityFetcher,
               1,
-              false,
               1000);
       StreamObserver<TotalEntitiesResponse> mockResponseObserver = mock(StreamObserver.class);
 
@@ -1171,7 +1140,6 @@ public class EntityQueryServiceImplTest {
               new EntityCounterMetricSender(),
               entityFetcher,
               1,
-              false,
               1000);
       StreamObserver<TotalEntitiesResponse> mockResponseObserver = mock(StreamObserver.class);
 

--- a/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityQueryServiceTest.java
+++ b/entity-service/src/integrationTest/java/org/hypertrace/entity/service/service/EntityQueryServiceTest.java
@@ -102,7 +102,6 @@ import org.hypertrace.entity.v1.entitytype.EntityType;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -649,7 +648,6 @@ public class EntityQueryServiceTest {
   }
 
   @Test
-  @Disabled("Disabled until we enable querying based on the new Query DTO")
   void testExecuteWithEqualsArrayFilter() {
     String filterValue1 = generateRandomUUID();
     String filterValue2 = generateRandomUUID();
@@ -960,7 +958,6 @@ public class EntityQueryServiceTest {
   }
 
   @Test
-  @Disabled("Disabled until we enable querying based on the new Query DTO")
   void testExecuteWithAggregations() {
     // create and upsert some entities
     Entity entity1 =

--- a/entity-service/src/main/resources/configs/common/application.conf
+++ b/entity-service/src/main/resources/configs/common/application.conf
@@ -12,7 +12,6 @@ entity.service.config = {
     }
   }
   publish.change.events = false
-  query.aggregation.enabled = false
 }
 attribute.service.config = {
   host = localhost

--- a/helm/templates/entity-service-config.yaml
+++ b/helm/templates/entity-service-config.yaml
@@ -19,7 +19,6 @@ data:
         }
       }
       publish.change.events = {{ .Values.entityServiceConfig.publishChangeEvents }}
-      query.aggregation.enabled = {{ .Values.entityServiceConfig.queryAggregationEnabled }}
     }
     entity.service.change = {
       enabled.entity.types = {{ .Values.entityServiceConfig.changeEnabledEntityTypes | toJson }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -87,7 +87,6 @@ serviceSelectorLabels:
 entityServiceConfig:
   name: entity-service-config
   publishChangeEvents: false
-  queryAggregationEnabled: false
   dataStoreType: "mongo"
   mongo:
     host: mongo


### PR DESCRIPTION
## Description
Removed the queryAggregationEnabled flag as the `aggregate()` is supported for both mongo and postgres now.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
