### PR TITLE
update max string length for bulk update matching all filter api

### DIFF
--- a/entity-service-change-event-generator/build.gradle.kts
+++ b/entity-service-change-event-generator/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     implementation("org.glassfish.jersey.core:jersey-common:2.34") {
       because("https://snyk.io/vuln/SNYK-JAVA-ORGGLASSFISHJERSEYCORE-1255637")
     }
-    implementation("org.apache.commons:commons-compress:1.21") {
+    implementation("org.apache.commons:commons-compress:1.26") {
       because("Multiple vulnerabilities")
     }
     runtimeOnly("org.jetbrains.kotlin:kotlin-stdlib:1.6.21") {
@@ -28,7 +28,7 @@ dependencies {
   }
 
   runtimeOnly("io.confluent:kafka-protobuf-serializer")
-  implementation(platform("org.hypertrace.core.kafkastreams.framework:kafka-bom:0.4.2"))
+  implementation(platform("org.hypertrace.core.kafkastreams.framework:kafka-bom:0.4.7"))
 
   annotationProcessor("org.projectlombok:lombok:1.18.18")
   compileOnly("org.projectlombok:lombok:1.18.18")

--- a/entity-service-factory/build.gradle.kts
+++ b/entity-service-factory/build.gradle.kts
@@ -8,5 +8,5 @@ dependencies {
   implementation(project(":entity-service-attribute-translator"))
   implementation(project(":entity-service-impl"))
   implementation(project(":entity-service-change-event-generator"))
-  implementation("org.hypertrace.core.documentstore:document-store:0.7.55")
+  implementation("org.hypertrace.core.documentstore:document-store:0.7.58")
 }

--- a/entity-service-impl/build.gradle.kts
+++ b/entity-service-impl/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
   annotationProcessor("org.projectlombok:lombok:1.18.22")
   compileOnly("org.projectlombok:lombok:1.18.18")
 
-  implementation("org.hypertrace.core.documentstore:document-store:0.7.55")
+  implementation("org.hypertrace.core.documentstore:document-store:0.7.58")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.12.6")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.12.6")
   implementation("org.hypertrace.core.attribute.service:caching-attribute-service-client:0.14.15")

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/EntityQueryServiceImplTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/query/service/EntityQueryServiceImplTest.java
@@ -137,7 +137,8 @@ public class EntityQueryServiceImplTest {
                       entityFetcher,
                       mock(Channel.class),
                       1,
-                      1000);
+                      1000,
+                      5000);
 
               eqs.update(null, mockResponseObserver);
 
@@ -167,7 +168,8 @@ public class EntityQueryServiceImplTest {
                       entityFetcher,
                       mock(Channel.class),
                       1,
-                      1000);
+                      1000,
+                      5000);
 
               eqs.update(EntityUpdateRequest.newBuilder().build(), mockResponseObserver);
 
@@ -198,7 +200,8 @@ public class EntityQueryServiceImplTest {
                       entityFetcher,
                       mock(Channel.class),
                       1,
-                      1000);
+                      1000,
+                      5000);
 
               eqs.update(
                   EntityUpdateRequest.newBuilder().setEntityType(TEST_ENTITY_TYPE).build(),
@@ -231,7 +234,8 @@ public class EntityQueryServiceImplTest {
                       entityFetcher,
                       mock(Channel.class),
                       1,
-                      1000);
+                      1000,
+                      5000);
 
               eqs.update(
                   EntityUpdateRequest.newBuilder()
@@ -293,7 +297,8 @@ public class EntityQueryServiceImplTest {
                       entityFetcher,
                       mock(Channel.class),
                       1,
-                      1000);
+                      1000,
+                      5000);
               eqs.update(updateRequest, mockResponseObserver);
               return null;
             });
@@ -330,7 +335,8 @@ public class EntityQueryServiceImplTest {
                         entityFetcher,
                         mock(Channel.class),
                         1,
-                        1000);
+                        1000,
+                        5000);
 
                 eqs.bulkUpdate(null, mockResponseObserver);
 
@@ -361,7 +367,8 @@ public class EntityQueryServiceImplTest {
                         entityFetcher,
                         mock(Channel.class),
                         1,
-                        1000);
+                        1000,
+                        5000);
 
                 eqs.bulkUpdate(BulkEntityUpdateRequest.newBuilder().build(), mockResponseObserver);
 
@@ -392,7 +399,8 @@ public class EntityQueryServiceImplTest {
                         entityFetcher,
                         mock(Channel.class),
                         1,
-                        1000);
+                        1000,
+                        5000);
 
                 eqs.bulkUpdate(
                     BulkEntityUpdateRequest.newBuilder().setEntityType(TEST_ENTITY_TYPE).build(),
@@ -432,7 +440,8 @@ public class EntityQueryServiceImplTest {
                         entityFetcher,
                         mock(Channel.class),
                         1,
-                        1000);
+                        1000,
+                        5000);
                 eqs.bulkUpdate(bulkUpdateRequest, mockResponseObserver);
                 return null;
               });
@@ -478,7 +487,8 @@ public class EntityQueryServiceImplTest {
                         entityFetcher,
                         mock(Channel.class),
                         1,
-                        1000);
+                        1000,
+                        5000);
                 eqs.bulkUpdate(bulkUpdateRequest, mockResponseObserver);
                 return null;
               });
@@ -518,7 +528,8 @@ public class EntityQueryServiceImplTest {
                         entityFetcher,
                         mock(Channel.class),
                         1,
-                        1000);
+                        1000,
+                        5000);
 
                 eqs.bulkUpdateAllMatchingFilter(null, mockResponseObserver);
 
@@ -551,7 +562,8 @@ public class EntityQueryServiceImplTest {
                         entityFetcher,
                         mock(Channel.class),
                         1,
-                        1000);
+                        1000,
+                        5000);
 
                 eqs.bulkUpdateAllMatchingFilter(
                     BulkUpdateAllMatchingFilterRequest.newBuilder().build(), mockResponseObserver);
@@ -588,7 +600,8 @@ public class EntityQueryServiceImplTest {
                         entityFetcher,
                         mock(Channel.class),
                         1,
-                        1000);
+                        1000,
+                        5000);
                 eqs.bulkUpdateAllMatchingFilter(bulkUpdateRequest, mockResponseObserver);
 
                 verify(mockResponseObserver, times(1))
@@ -687,7 +700,8 @@ public class EntityQueryServiceImplTest {
                         entityFetcher,
                         mock(Channel.class),
                         1,
-                        1000);
+                        1000,
+                        5000);
                 eqs.bulkUpdateAllMatchingFilter(bulkUpdateRequest, mockResponseObserver);
                 return null;
               });
@@ -726,7 +740,8 @@ public class EntityQueryServiceImplTest {
                       entityFetcher,
                       mock(Channel.class),
                       1,
-                      1000);
+                      1000,
+                      5000);
 
               eqs.execute(null, mockResponseObserver);
 
@@ -802,7 +817,8 @@ public class EntityQueryServiceImplTest {
                       new EntityCounterMetricSender(),
                       mock(Channel.class),
                       1,
-                      1000);
+                      1000,
+                      5000);
 
               eqs.execute(request, mockResponseObserver);
               return null;
@@ -893,7 +909,8 @@ public class EntityQueryServiceImplTest {
                       new EntityCounterMetricSender(),
                       mock(Channel.class),
                       2,
-                      1000);
+                      1000,
+                      5000);
 
               eqs.execute(request, mockResponseObserver);
               return null;
@@ -947,7 +964,8 @@ public class EntityQueryServiceImplTest {
                       entityFetcher,
                       mock(Channel.class),
                       1,
-                      1000);
+                      1000,
+                      5000);
               eqs.bulkUpdateEntityArrayAttribute(request, mockResponseObserver);
               return null;
             });
@@ -1020,7 +1038,8 @@ public class EntityQueryServiceImplTest {
                       entityFetcher,
                       mock(Channel.class),
                       100,
-                      1000);
+                      1000,
+                      5000);
 
               eqs.deleteEntities(request, mockResponseObserver);
             });
@@ -1093,7 +1112,8 @@ public class EntityQueryServiceImplTest {
                       entityFetcher,
                       mock(Channel.class),
                       100,
-                      1000);
+                      1000,
+                      5000);
 
               eqs.execute(request, mockResponseObserver);
             });
@@ -1140,7 +1160,8 @@ public class EntityQueryServiceImplTest {
               entityFetcher,
               mock(Channel.class),
               1,
-              1000);
+              1000,
+              5000);
       StreamObserver<TotalEntitiesResponse> mockResponseObserver = mock(StreamObserver.class);
 
       Context.current()
@@ -1186,7 +1207,8 @@ public class EntityQueryServiceImplTest {
               entityFetcher,
               mock(Channel.class),
               1,
-              1000);
+              1000,
+              5000);
       StreamObserver<TotalEntitiesResponse> mockResponseObserver = mock(StreamObserver.class);
 
       when(entitiesCollection.total(any())).thenReturn(123L);

--- a/entity-service/build.gradle.kts
+++ b/entity-service/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
   implementation(project(":entity-service-factory"))
 
   implementation("org.hypertrace.core.serviceframework:platform-grpc-service-framework:0.1.62")
-  implementation("org.hypertrace.core.documentstore:document-store:0.7.55")
+  implementation("org.hypertrace.core.documentstore:document-store:0.7.58")
 
   runtimeOnly("io.grpc:grpc-netty:1.57.2")
 

--- a/entity-service/src/integrationTest/resources/configs/entity-service/application.conf
+++ b/entity-service/src/integrationTest/resources/configs/entity-service/application.conf
@@ -23,7 +23,10 @@ entity.service.config = {
   publish.change.events = false
 }
 
-entity.query.service.response.chunk.size = 2
+entity.query.service = {
+  response.chunk.size = 2
+  max.string.length.for.update = 5000
+}
 eqs.change.notification.enabled.entity.types = ["*"]
 attribute.service.config = {
   host = localhost

--- a/helm/templates/entity-service-config.yaml
+++ b/helm/templates/entity-service-config.yaml
@@ -44,6 +44,7 @@ data:
         schema.registry.url = "http://schema-registry-service:8081"
       }
     }
+    entity.query.service.max.string.length.for.update = {{ .Values.entityQueryService.maxStringLengthForUpdate }}
   {{- if .Values.attributes }}
     entity.service.attributeMap = [
   {{- range $i, $v := .Values.attributes }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -145,3 +145,6 @@ hpa:
   minReplicas: 1
   maxReplicas: 5
   targetCPUUtilizationPercentage: 80
+
+entityQueryService:
+  maxStringLengthForUpdate: 5000

--- a/owasp-suppressions.xml
+++ b/owasp-suppressions.xml
@@ -8,14 +8,6 @@
         <packageUrl regex="true">^pkg:maven/org\.apache\.avro/avro@.*$</packageUrl>
         <cve>CVE-2021-43045</cve>
     </suppress>
-    <suppress until="2023-07-31Z">
-        <notes><![CDATA[
-    Doesn't appear to be a real vulnerability, jackson maintainers discuss at https://github.com/FasterXML/jackson-databind/issues/3973
-    Revisit when suppression expires
-    ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
-        <vulnerabilityName>CVE-2023-35116</vulnerabilityName>
-    </suppress>
     <suppress>
         <notes><![CDATA[
     Any hypertrace core dep
@@ -39,14 +31,7 @@
         <packageUrl regex="true">^pkg:maven/com\.squareup\.wire/wire\-schema\-jvm@.*$</packageUrl>
         <cpe>cpe:/a:wire:wire</cpe>
     </suppress>
-    <suppress until="2023-11-30Z">
-        <notes><![CDATA[
-   file name: netty-handler-4.1.94.Final.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/io\.netty/netty.*@.*$</packageUrl>
-        <vulnerabilityName>CVE-2023-4586</vulnerabilityName>
-    </suppress>
-    <suppress until="2024-02-28Z">
+    <suppress until="2024-03-31Z">
         <notes><![CDATA[
    This CVE (rapid RST) is already mitigated as our servers aren't directly exposed, but it's also
    addressed in 1.59.1, which the CVE doesn't reflect (not all grpc impls versions are exactly aligned).


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

Also, making it configurable through helm values.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
