### PR TITLE
fix: handle NOT_IN operator transformation

### DIFF
--- a/entity-service-impl/src/main/java/org/hypertrace/entity/service/util/DocStoreConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/service/util/DocStoreConverter.java
@@ -315,7 +315,7 @@ public class DocStoreConverter {
                       OBJECT_MAPPER.readTree(JSONFORMAT_PRINTER.print(v)), Map.class));
             }
             filter.setValue(listNodes);
-          } else if (filter.getOp().equals(Op.IN)) {
+          } else if (filter.getOp().equals(Op.IN) || filter.getOp().equals(Op.NOT_IN)) {
             List<Object> listNodes = new ArrayList<>();
             for (AttributeValue v : attributeValue.getValueList().getValuesList()) {
               listNodes.add(getValue(v.getValue()));
@@ -323,7 +323,7 @@ public class DocStoreConverter {
             filter.setValue(listNodes);
           } else {
             throw new UnsupportedOperationException(
-                "Only CONTAINS, EQ and IN conditions supported for attribute values of type list");
+                "Only CONTAINS, EQ, IN and NOT_IN conditions supported for attribute values of type list");
           }
         }
         break;

--- a/entity-service-impl/src/main/java/org/hypertrace/entity/service/util/DocStoreConverter.java
+++ b/entity-service-impl/src/main/java/org/hypertrace/entity/service/util/DocStoreConverter.java
@@ -420,6 +420,7 @@ public class DocStoreConverter {
       case NOT_EXISTS:
         return Op.NOT_EXISTS;
       case NOT_IN:
+        return Op.NOT_IN;
       default:
         throw new IllegalArgumentException(
             String.format("Operator conversion is not supported for: %s", operator));

--- a/entity-service-impl/src/test/java/org/hypertrace/entity/service/util/DocStoreConverterTest.java
+++ b/entity-service-impl/src/test/java/org/hypertrace/entity/service/util/DocStoreConverterTest.java
@@ -892,12 +892,6 @@ public class DocStoreConverterTest {
         () -> {
           createAndTransformQuery(Operator.UNDEFINED);
         });
-    // There's currently no op for NOT_IN
-    Assertions.assertThrows(
-        IllegalArgumentException.class,
-        () -> {
-          createAndTransformQuery(Operator.NOT_IN);
-        });
   }
 
   private void testFilterOpConversionForEntityServiceOp(


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
